### PR TITLE
2023 update

### DIFF
--- a/base-template.md
+++ b/base-template.md
@@ -53,7 +53,7 @@ Tables 1 and 2 also document conformance with:
 - EN 301 549:  Chapter 9 - Web, Sections 10.1-10.4 of Chapter 10 - Non-Web documents, and Sections 11.1-11.4 and 11.8.2 of Chapter 11 - Non-Web Software (open and closed functionality), and Sections 12.1.2 and 12.2.4 of Chapter 12 – Documentation
 - Revised Section 508: Chapter 5 – 501.1 Scope, 504.2 Content Creation or Editing, and Chapter 6 – 602.3 Electronic Support Documentation.
 
-**Note**: When reporting on conformance with the WCAG 2.x Success Criteria, they are scoped for full pages, complete processes, and accessibility-supported ways of using technology as documented in the [WCAG 2.0 Conformance Requirements](https://www.w3.org/TR/WCAG20/#conformance-reqs).
+**Note**: When reporting on conformance with the WCAG 2.x Success Criteria, they are scoped for full pages, complete processes, and accessibility-supported ways of using technology as documented in the [WCAG 2.1 Conformance Requirements](https://www.w3.org/TR/WCAG21/#conformance-reqs).
 
 ### Table 1: Success Criteria, Level A
 
@@ -1137,7 +1137,7 @@ Tables 1 and 2 also document conformance with:
 
 ### Table 3: Success Criteria, Level AAA
 
-Notes: This product has not been evaluated for WCAG 2.0 Level AAA conformance.
+Notes: This product has not been evaluated for WCAG 2.x Level AAA conformance.
 
 ## Revised Section 508 Report
 
@@ -1216,8 +1216,8 @@ Notes: This product is a web software application and is not subject to the requ
 </thead>
 <tbody>
 <tr>
-<td>501.1 Scope – Incorporation of WCAG 2.0 AA</td>
-<td>See <a href="#WCAG">WCAG 2.0</a> section</td>
+<td>501.1 Scope – Incorporation of WCAG 2.x AA</td>
+<td>See <a href="#WCAG">WCAG 2.x</a> section</td>
 <td>See information in WCAG section</td>
 </tr>
 <tr>
@@ -1342,7 +1342,7 @@ Notes: This product is a web software application and is not subject to the requ
 </tr>
 <tr>
 <td headers="504-authoring chap-5-criteria">504.2 Content Creation or Editing (if not authoring tool, enter “not applicable”)</td>
-<td headers="504-authoring chap-5-conformance">See <a href="#WCAG">WCAG 2.0</a> section</td>
+<td headers="504-authoring chap-5-conformance">See <a href="#WCAG">WCAG 2.x</a> section</td>
 <td headers="504-authoring chap-5-remarks">See information in WCAG section</td>
 </tr>
 <tr>
@@ -1511,7 +1511,7 @@ Notes: This product is a web software application and is not subject to the requ
 
 ### Chapter [9: Web](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=45)
 
-Notes: Please see [WCAG 2.0 section](#wcag-2.0-report).
+Notes: Please see [WCAG 2.x section](#wcag-21-report).
 
 ### Chapter [10: Non-web Documents](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=52)
 
@@ -1533,7 +1533,7 @@ Notes: This product does not include non-web documents and is therefore not subj
   </tr>
 <tr>
 <td headers="11-gen chap-11-criteria">11.1.1 through 11.4.1.3</td>
-<td headers="11-gen chap-11-conformance">See <a ref="#WCAG">WCAG 2.0</a> Section</td>
+<td headers="11-gen chap-11-conformance">See <a ref="#WCAG">WCAG 2.x</a> Section</td>
 <td headers="11-gen chap-11-remarks">See information in WCAG section</td>
 </tr>
 <tr>
@@ -1655,7 +1655,7 @@ Notes: This product does not include non-web documents and is therefore not subj
 </tr>
 <tr>
 <td headers="11-content-tech chap-11-criteria">11.8.2 Accessible content creation (if not authoring tool, enter “not applicable”)</td>
-<td headers="11-content-tech chap-11-conformance">See <a ref="#WCAG"> WCAG 2.0 </a>section</td>
+<td headers="11-content-tech chap-11-conformance">See <a ref="#WCAG"> WCAG 2.x </a>section</td>
 <td headers="11-content-tech chap-11-remarks">See information in WCAG section</td>
 </tr>
 <tr>

--- a/base-template.md
+++ b/base-template.md
@@ -6,8 +6,7 @@
 **Product Description**: \!INSERT PRODUCT DESCRIPTION\!  
 **Contact information**: Please contact your Institutional Sales representative.  
 **Notes**:  
-**Evaluation Methods Used**: Conformance to the listed accessibility standards has been evaluated by Springer Nature's dedicated Accessibility Specialists. We use a combination of static analysis tools (including but not limited to Axe, WAVE, and all of the tools described in our [Frontend Playbook's Accessibility Guide](https://github.com/springernature/frontend-playbook/blob/main/accessibility/tools.md)). Additionally, we perform manual testing (also described in our Frontend Playbook under the "Manual testing" and "Assistive technology" sections).  
-
+**Evaluation Methods Used**: Conformance to the listed accessibility standards has been evaluated by Springer Nature's dedicated Accessibility Specialists. We use a combination of static analysis tools (including but not limited to [axe by Deque](https://www.deque.com/axe/), [WAVE by WebAIM](https://wave.webaim.org/extension/), and all of the tools described in our [Frontend Playbook's Accessibility Guide](https://github.com/springernature/frontend-playbook/blob/main/accessibility/tools.md)). Our manual testing uses [WCAG-EM](https://www.w3.org/WAI/test-evaluate/conformance/wcag-em/) as its base strategy, and further details are also described in our Frontend Playbook under the "Manual testing" and "Assistive technology" sections. 
 
 ## Applicable Standards/Guidelines
 
@@ -1140,7 +1139,7 @@ Tables 1 and 2 also document conformance with:
 
 Notes: This product has not been evaluated for WCAG 2.0 Level AAA conformance.
 
-## Revised Section 508 Report 
+## Revised Section 508 Report
 
 ### Chapter 3: [Functional Performance Criteria](https://www.access-board.gov/ict/#chapter-3-functional-performance-criteria) (FPC)
 
@@ -1448,11 +1447,11 @@ Notes: This report covers accessibility conformance for the web product and does
 
 Notes: This product supports standard web assistive technologies and is therefore not subject to the Closed Functionality criteria described in this chapter.
 
-### Chapter [6: ICT with Two-Way Voice Communication](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=30) 
+### Chapter [6: ICT with Two-Way Voice Communication](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=30)
 
 Notes: This product does not offer two-way voice communication and is therefore not subject to the requirements of this chapter.
 
-### Chapter [7: ICT with Video Capabilities](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=35) 
+### Chapter [7: ICT with Video Capabilities](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=35)
 
 Notes:
 
@@ -1530,7 +1529,7 @@ Notes: This product does not include non-web documents and is therefore not subj
 </thead>
 <tbody>
   <tr>
-  <th scope="column" colspan="3" id="11-gen">11.0 General (informative)</th> 
+  <th scope="column" colspan="3" id="11-gen">11.0 General (informative)</th>
   </tr>
 <tr>
 <td headers="11-gen chap-11-criteria">11.1.1 through 11.4.1.3</td>

--- a/base-template.md
+++ b/base-template.md
@@ -6,7 +6,7 @@
 **Product Description**: \!INSERT PRODUCT DESCRIPTION\!  
 **Contact information**: Please contact your Institutional Sales representative.  
 **Notes**:  
-**Evaluation Methods Used**: Conformance to the listed accessibility standards has been evaluated by Springer Nature's dedicated Accessibility Specialists. We use a combination of static analysis tools (including but not limited to [axe by Deque](https://www.deque.com/axe/), [WAVE by WebAIM](https://wave.webaim.org/extension/), and all of the tools described in our [Frontend Playbook's Accessibility Guide](https://github.com/springernature/frontend-playbook/blob/main/accessibility/tools.md)). Our manual testing uses [WCAG-EM](https://www.w3.org/WAI/test-evaluate/conformance/wcag-em/) as its base strategy, and further details are also described in our Frontend Playbook under the "Manual testing" and "Assistive technology" sections. 
+**Evaluation Methods Used**: Conformance to the listed accessibility standards has been evaluated by Springer Nature's dedicated Accessibility Specialists. We use a combination of static analysis tools (including but not limited to [axe by Deque](https://www.deque.com/axe/), [WAVE by WebAIM](https://wave.webaim.org/extension/), and all of the tools described in our [Frontend Playbook's Accessibility Guide](https://github.com/springernature/frontend-playbook/blob/main/accessibility/tools.md)). Our manual testing uses [WCAG-EM](https://www.w3.org/WAI/test-evaluate/conformance/wcag-em/) as its base strategy, and further details are also described in our Frontend Playbook under the "Manual testing" and "Assistive technology" sections.
 
 ## Applicable Standards/Guidelines
 
@@ -45,7 +45,7 @@ The terms used in the Conformance Level information are defined as follows:
 - **Partially Supports**: Some functionality of the product does not meet the criterion.
 - **Does Not Support**: The majority of product functionality does not meet the criterion.
 - **Not Applicable**: The criterion is not relevant to the product.
-- **Not Evaluated**: The product has not been evaluated against the criterion. This can be used only in WCAG 2.0 Level AAA.
+- **Not Evaluated**: The product has not been evaluated against the criterion. This can be used only in WCAG 2.x Level AAA.
 
 ## WCAG 2.1 Report
 

--- a/nature.md
+++ b/nature.md
@@ -1324,7 +1324,7 @@ Third party scripts including the Disqus commenting widget, or other widgets tha
 
 ### Table 3: Success Criteria, Level AAA
 
-Notes: This product has not been evaluated for WCAG 2.1 Level AAA conformance.
+Notes: This product has not been evaluated for WCAG 2.x Level AAA conformance.
 
 ## Revised Section 508 Report
 
@@ -1765,7 +1765,7 @@ Notes: This product does not include non-web documents and is therefore not subj
 <th scope="column" colspan="3" id="11-gen">11.0 General (informative)</th>
 </tr>
 <td headers="11-gen chap-11-criteria">11.1.1 through 11.4.1.3</td>
-<td headers "11-gen chap-11-conformance">See <a ref="#WCAG">WCAG 2.0</a> Section</td>
+<td headers "11-gen chap-11-conformance">See <a ref="#WCAG">WCAG 2.x</a> Section</td>
 <td headers "11-gen chap-11-remarks">See information in WCAG section</td>
 </tr>
 <tr>

--- a/nature.md
+++ b/nature.md
@@ -3,11 +3,11 @@
 
 **Report Date**: 22nd June 2022  
 **Name of Product/Version**: Nature.com _(we do not version our software)_  
-**Product Description**: 
+**Product Description**:
 Nature.com publishes peer-reviewed research, reviews and news across a number of journals. This report refers entirely to the accessibility of editorial, journal, and magazine web documents published at the top level domain of <a href="http://www.nature.com">www.nature.com</a>, including informational pages, and to all web documents found at idp.nature.com and payment.nature.com (for account management and subscription and payment management respectively).  
 **Contact information**: Please contact your Institutional Sales representative.  
 **Notes**:  
-**Evaluation Methods Used**: Conformance to the listed accessibility standards has been evaluated by Springer Nature's dedicated Accessibility Specialists. We use a combination of static analysis tools (including but not limited to Axe, WAVE, and all of the tools described in our [Frontend Playbook's Accessibility Guide](https://github.com/springernature/frontend-playbook/blob/main/accessibility/tools.md)). Additionally, we perform manual testing (also described in our Frontend Playbook under the "Manual testing" and "Assistive technology" sections).  
+**Evaluation Methods Used**: Conformance to the listed accessibility standards has been evaluated by Springer Nature's dedicated Accessibility Specialists. We use a combination of static analysis tools (including but not limited to [axe by Deque](https://www.deque.com/axe/), [WAVE by WebAIM](https://wave.webaim.org/extension/), and all of the tools described in our [Frontend Playbook's Accessibility Guide](https://github.com/springernature/frontend-playbook/blob/main/accessibility/tools.md)). Our manual testing uses [WCAG-EM](https://www.w3.org/WAI/test-evaluate/conformance/wcag-em/) as its base strategy, and further details are also described in our Frontend Playbook under the "Manual testing" and "Assistive technology" sections. 
 
 
 ## Applicable Standards/Guidelines
@@ -33,7 +33,7 @@ This report covers the degree of conformance for the following accessibility sta
 <td nowrap><strong>Yes</strong></td>
 </tr>
 <tr>
-<td><a href="https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.01.01_60/en_301549v030101p.pdf">EN 301 549 Accessibility requirements for ICT products and services - V3.1.1 (2019-11)</a> AND <a href="https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf">EN 301 549 Accessibility requirements for ICT products and services - V3.2.1 (2021-03)</a></td> 
+<td><a href="https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.01.01_60/en_301549v030101p.pdf">EN 301 549 Accessibility requirements for ICT products and services - V3.1.1 (2019-11)</a> AND <a href="https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf">EN 301 549 Accessibility requirements for ICT products and services - V3.2.1 (2021-03)</a></td>
 <td nowrap><strong>Yes</strong></td>
 </tr>
 </tbody>
@@ -95,7 +95,7 @@ Background images such as icons on user interface elements are generally identif
 <br><br>
 We mark up some images so that they can be ignored by Assistive Technologies if they are <a href="https://www.w3.org/TR/WCAG21/#dfn-pure-decoration"><i>pure decoration</i></a> (as defined by WCAG 2.1).
 <br><br>
-The Nature subscription pages at <a href="https://www.nature.com/nature/subscribe">https://www.nature.com/nature/subscribe</a> currently contain SVG images without text alternatives, and decorative SVG images that are not marked up to be ignored by Assistive Technologies. We are actively working to repair these problems. 
+The Nature subscription pages at <a href="https://www.nature.com/nature/subscribe">https://www.nature.com/nature/subscribe</a> currently contain SVG images without text alternatives, and decorative SVG images that are not marked up to be ignored by Assistive Technologies. We are actively working to repair these problems.
 <br><br>
 Third party scripts may inject non-text content without text alternatives, or with inadequate text alternatives. These include images in advertising scripts and in Disqus commenting widgets. When we become aware of deficiencies, we contact third party suppliers to request repairs.
 </td>
@@ -121,9 +121,9 @@ Third party scripts may inject non-text content without text alternatives, or wi
 </ul></td>
 <td>Partially Supports</td>
 <td>
-Nature.com has a diverse mix of multimedia content, both self-hosted and hosted on third party sites. Video-only content is generally used to support text-based content. 
+Nature.com has a diverse mix of multimedia content, both self-hosted and hosted on third party sites. Video-only content is generally used to support text-based content.
 <br><br>
-Audio-only content may be used to support text-based content. Audio-only content may also be used in Podcasts across various journals. Some but not all podcasts provide transcripts. 
+Audio-only content may be used to support text-based content. Audio-only content may also be used in Podcasts across various journals. Some but not all podcasts provide transcripts.
 <br><br>
 We currently have no method of confirming the inclusion of adequate media alternatives or transcripts. 	
 </td>
@@ -149,7 +149,7 @@ We currently have no method of confirming the inclusion of adequate media altern
 </ul></td>
 <td>Partially Supports</td>
 <td>
-Nature.com has a diverse mix of multimedia content, both self-hosted and hosted on third party sites. Captions and/or transcripts may be provided for some pre-recorded content, but we currently have no method of confirming the inclusion of transcripts or captions. 
+Nature.com has a diverse mix of multimedia content, both self-hosted and hosted on third party sites. Captions and/or transcripts may be provided for some pre-recorded content, but we currently have no method of confirming the inclusion of transcripts or captions.
 </td>
 </tr>
 <tr valign="top">
@@ -173,7 +173,7 @@ Nature.com has a diverse mix of multimedia content, both self-hosted and hosted 
 </ul></td>
 <td>Partially Supports</td>
 <td>
-Nature.com has a diverse mix of multimedia content, both self-hosted and hosted on third party sites. Audio description is not generally used across our content, but some media may provide media alternatives such as text descriptions of video content. 
+Nature.com has a diverse mix of multimedia content, both self-hosted and hosted on third party sites. Audio description is not generally used across our content, but some media may provide media alternatives such as text descriptions of video content.
 <br><br>
 We currently have no method of confirming the inclusion of adequate media alternatives.
 </td>
@@ -201,9 +201,9 @@ We currently have no method of confirming the inclusion of adequate media altern
 <td>
 We generally use progressive enhancement techniques and semantically-correct markup so that information, structure, and relationships can be understood independent of presentation.
 <br><br>
-We make use of WAI-ARIA roles to support landmarks, and use WAI-ARIA roles and properties when required for more complex functionality such as popup menus and dialogs. 
+We make use of WAI-ARIA roles to support landmarks, and use WAI-ARIA roles and properties when required for more complex functionality such as popup menus and dialogs.
 <br><br>
-Some parts of the checkout flow and the "My Account" pages contain unsemantic markup, including out-of-sequence headings and incorrectly-applied landmarks. We are actively working to find and repair these problems. 
+Some parts of the checkout flow and the "My Account" pages contain unsemantic markup, including out-of-sequence headings and incorrectly-applied landmarks. We are actively working to find and repair these problems.
 <br><br>
 Some functionality may omit required WAI-ARIA roles, states, or attributes, or misuse WAI-ARIA markup and techniques. When we become aware of content with these problems, we immediately take steps to repair the issues.
 <br><br>
@@ -261,7 +261,7 @@ The pages of this product do not depend solely on sensory characteristics such a
 <br><br>
 Icons may be displayed to control functionality, but adjacent visible text labels or WAI-ARIA labels are also provided to ensure that relationships are available to Assistive Technologies.
 <br><br>
-Some complex images supplied by submission authors may rely on sensory characteristics to be understood. Examples may include images of charts, graphs, or maps. Generally, these images are used to supplement text content. 
+Some complex images supplied by submission authors may rely on sensory characteristics to be understood. Examples may include images of charts, graphs, or maps. Generally, these images are used to supplement text content.
 </td>
 </tr>
 <tr id="use-of-color" valign="top">
@@ -289,7 +289,7 @@ Colour alone is not used to convey information in the pages of this product.
 <br><br>
 Links and icons may use colour to indicate hover or active states. These are supplemented with visible focus rings and/or text decoration underlines and/or luminosity differences per WAI techniques <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G183">G183</a> and <a href="https://www.w3.org/WAI/WCAG21/Techniques/css/C15">C15</a>.
 <br><br>
-Some complex images supplied by submission authors may rely on colour as the only visual means of understanding information. Examples may include images of charts, graphs, or maps. Generally, these images are used to supplement text content. 
+Some complex images supplied by submission authors may rely on colour as the only visual means of understanding information. Examples may include images of charts, graphs, or maps. Generally, these images are used to supplement text content.
 </td>
 </tr>
 <tr valign="top">
@@ -313,7 +313,7 @@ Some complex images supplied by submission authors may rely on colour as the onl
 </ul></td>
 <td>Partially Supports</td>
 <td>
-Content supplied by us does not play automatically. All audio files supplied by us, either hosted on our own platform or through a third party, have mechanisms for pausing, stopping, and controlling volume. 
+Content supplied by us does not play automatically. All audio files supplied by us, either hosted on our own platform or through a third party, have mechanisms for pausing, stopping, and controlling volume.
 <br><br>
 Third party advertisements may load video and audio that automatically starts, and may not provide adequate controls for pausing, stopping, and/or controlling volume. When we become aware of active advertisements with these problems, we immediately take steps to remove those advertisements from our pages.
 </td>
@@ -345,7 +345,7 @@ All first-party components in Nature.com can be navigated by keyboard alone. Com
 <br><br>
 Third party advertising scripts may inject content that cannot be interacted with easily or at all by keyboard.
 <br><br>
-Other types of third party content such as JavaScript-based file viewers (e.g. Figshare), commenting systems, or customer services widgets may be difficult to use with keyboard alone. When we become aware of deficiencies, we contact third party suppliers to request repairs. Additionally, where possible, we aim to provide equivalent alternatives to problematic content. 
+Other types of third party content such as JavaScript-based file viewers (e.g. Figshare), commenting systems, or customer services widgets may be difficult to use with keyboard alone. When we become aware of deficiencies, we contact third party suppliers to request repairs. Additionally, where possible, we aim to provide equivalent alternatives to problematic content.
 </td>
 </tr>
 <tr valign="top">
@@ -369,7 +369,7 @@ Other types of third party content such as JavaScript-based file viewers (e.g. F
 </ul></td>
 <td>Partially Supports</td>
 <td>
-Keyboard trapping inside components on Nature.com pages is rare, and in most cases is managed appropriately, allowing focus to be moved away from any component using standard keystrokes (<kbd>tab</kbd>, <kbd>shift</kbd>, <kbd>esc</kbd>). 
+Keyboard trapping inside components on Nature.com pages is rare, and in most cases is managed appropriately, allowing focus to be moved away from any component using standard keystrokes (<kbd>tab</kbd>, <kbd>shift</kbd>, <kbd>esc</kbd>).
 <br><br>
 Third party content such as modal dialogs or the Disqus commenting widget may trap focus and provide inadequate methods of escaping. When we become aware of deficiencies, we contact third party suppliers to request repairs.
 </td>
@@ -437,9 +437,9 @@ Third party content such as modal dialogs or the Disqus commenting widget may tr
 <td>
 Any moving, blinking or scrolling content on Nature.com generally does not start automatically, and is complemented by controls that allow users to pause or otherwise stop the content. Moving images in the form of gifs may not meet this criterion.  
 <br><br>
-Automatically updating information is rare on Nature.com. The Disqus commenting widget may update new comments on screen automatically. If users are actively interacting with the widget, then new comments may be progressively disclosed to users at their request by activating a "load new comments" button. 
+Automatically updating information is rare on Nature.com. The Disqus commenting widget may update new comments on screen automatically. If users are actively interacting with the widget, then new comments may be progressively disclosed to users at their request by activating a "load new comments" button.
 <br><br>
-Third party advertising scripts may inject content that automatically moves or blinks and lasts more than five seconds, without providing a mechanism to pause, stop, or hide that content. 
+Third party advertising scripts may inject content that automatically moves or blinks and lasts more than five seconds, without providing a mechanism to pause, stop, or hide that content.
 </td>
 </tr>
 <tr valign="top">
@@ -511,9 +511,9 @@ Some third party content, for example embedded widgets that provide alternative 
 </ul></td>
 <td>Partially Supports</td>
 <td>
-Most of the pages on Nature.com have unique page titles that describe the purpose of the page. 
+Most of the pages on Nature.com have unique page titles that describe the purpose of the page.
 <br><br>
-Some pages (e.g in checkout flows) do not have unique page titles at every stage in a process. We are actively working to find and repair these problems. 
+Some pages (e.g in checkout flows) do not have unique page titles at every stage in a process. We are actively working to find and repair these problems.
 </td>
 </tr>
 <tr valign="top">
@@ -539,7 +539,7 @@ Some pages (e.g in checkout flows) do not have unique page titles at every stage
 <td>
 The meaning or operation of the pages on Nature.com is generally unaffected by focus order. The focus order of all page content matches the visual order.
 <br><br>
-Third party scripts including advertising scripts, the Disqus commenting widget, or survey or customer services widgets (among others), may inject content where the focus order does not match the visual order. The operation and meaning of these components should be unaffected by the focus order. 
+Third party scripts including advertising scripts, the Disqus commenting widget, or survey or customer services widgets (among others), may inject content where the focus order does not match the visual order. The operation and meaning of these components should be unaffected by the focus order.
 </td>
 </tr>
 <tr id="link-purpose-in-context" valign="top">
@@ -563,9 +563,9 @@ Third party scripts including advertising scripts, the Disqus commenting widget,
 </ul></td>
 <td>Partially Supports</td>
 <td>
-Generally, the purpose of first party links can be determined by their descriptive text labels. Most linked images or icons have alternative text or supplementary text labels. 
+Generally, the purpose of first party links can be determined by their descriptive text labels. Most linked images or icons have alternative text or supplementary text labels.
 <br><br>
-In submitted articles, anchor links that refer to supplementary figures or tables may have insufficient context in their link text (e.g. figure numbers only). In limited cases we may support inadequate link text with the use of WAI-ARIA techniques. We are actively working to repair these problems. 
+In submitted articles, anchor links that refer to supplementary figures or tables may have insufficient context in their link text (e.g. figure numbers only). In limited cases we may support inadequate link text with the use of WAI-ARIA techniques. We are actively working to repair these problems.
 <br><br>
 Third party scripts including advertising scripts, the Disqus commenting widget, survey or customer services widgets (among others), may inject content that includes links with no accessible text, or poorly-named accessible text. When we become aware of deficiencies, we contact third party suppliers to request repairs.
 </td>
@@ -589,7 +589,7 @@ Third party scripts including advertising scripts, the Disqus commenting widget,
 <td>This product generally does not contain any functionality that uses multipoint or path-based gestures for operation.
 <br>
 <br>
-Special feature content may use multipoint gestures for functionality such as pan and zoom controls. Alternatives to multipoint gestures are provided, including single point and keyboard controls. For complex functionality, simple instructions may be provided to explain the available options. 
+Special feature content may use multipoint gestures for functionality such as pan and zoom controls. Alternatives to multipoint gestures are provided, including single point and keyboard controls. For complex functionality, simple instructions may be provided to explain the available options.
 </td>
 </tr>
 <tr id="pointer-cancellation" valign="top">
@@ -627,7 +627,7 @@ Special feature content may use multipoint gestures for functionality such as pa
 </td>
 <td>Partially Supports</td>
 <td>
-In most cases where controls contain visible text, that text is also the label for the control. Some third party scripts may inject content that does not meet this criterion. Supplementary pages (such as special features or marketing pages) may fail to meet this criterion. 
+In most cases where controls contain visible text, that text is also the label for the control. Some third party scripts may inject content that does not meet this criterion. Supplementary pages (such as special features or marketing pages) may fail to meet this criterion.
 </td>
 </tr>
 <tr id="motion-actuation" valign="top">
@@ -737,9 +737,9 @@ All of the pages in this product use the language attribute on the HTML element 
 </ul></td>
 <td>Partially Supports</td>
 <td>
-Where user input errors are automatically detected by our own software, those errors are identified with warning text adjacent to the input field. We do not rely on visual characteristics alone (e.g. colour). 
+Where user input errors are automatically detected by our own software, those errors are identified with warning text adjacent to the input field. We do not rely on visual characteristics alone (e.g. colour).
 <br><br>
-Pages located at payment.nature.com rely solely on built-in browser error checking, and do not identify errors in text. Some users with and without Assistive Technology may be unable to access these error states. 
+Pages located at payment.nature.com rely solely on built-in browser error checking, and do not identify errors in text. Some users with and without Assistive Technology may be unable to access these error states.
 <br><br>
 Third party scripts including the Disqus commenting widget, or other widgets that accept user input, may automatically detect errors but fail to present the errors to users in text. They may rely on visual characteristics alone to indicate user input errors, or place error text in locations that are difficult for screen reader users to access. When we become aware of deficiencies, we contact third party suppliers to request repairs.
 </td>
@@ -765,9 +765,9 @@ Third party scripts including the Disqus commenting widget, or other widgets tha
 </ul></td>
 <td>Partially Supports</td>
 <td>
-Generally, visible and appropriately associated labels are provided for input fields. In some cases, a visually-hidden label may be provided instead. 
+Generally, visible and appropriately associated labels are provided for input fields. In some cases, a visually-hidden label may be provided instead.
 <br><br>
-Additional instructions for specific input fields may not be adequately associated (e.g. with WAI-ARIA) with the fields they describe. We are actively working to find and repair these problems. 
+Additional instructions for specific input fields may not be adequately associated (e.g. with WAI-ARIA) with the fields they describe. We are actively working to find and repair these problems.
 <br><br>
 </td>
 </tr>
@@ -820,7 +820,7 @@ Third party advertising scripts may inject content that omits start and end tags
 <td>
 The pages of this product generally use standard HTML and WAI-ARIA attributes to describe the identity, operation, and state of user interface elements to Assistive Technologies.
 <br><br>
-WAI-ARIA attributes may be omitted where they would be useful, for example to support HTML5 features that are not widely supported by client technology. In other cases WAI-ARIA roles or attributes may be misused in ways that cause elements to have misleading semantics. We are actively working to find and repair these problems. 
+WAI-ARIA attributes may be omitted where they would be useful, for example to support HTML5 features that are not widely supported by client technology. In other cases WAI-ARIA roles or attributes may be misused in ways that cause elements to have misleading semantics. We are actively working to find and repair these problems.
 <br><br>
 Other third party scripts, including the Disqus commenting widget, may present interactive elements such as tooltips that lack adequate names and roles, making them difficult for screen reader users to access. When we become aware of deficiencies, we contact third party suppliers to request repairs.
 </td>
@@ -920,7 +920,7 @@ Other third party scripts, including the Disqus commenting widget, may present i
 <td>
 A limited number of form fields may have autocomplete values that allow the field purpose to be determined programmatically, but we have not widely implemented this functionality.
 <br><br>
-Some fields, including those on the login and registration forms, have the <code>autocomplete="off"</code> property set. Users whose technology respects this property may be unable to fill form fields automatically. 
+Some fields, including those on the login and registration forms, have the <code>autocomplete="off"</code> property set. Users whose technology respects this property may be unable to fill form fields automatically.
 </td>
 </tr>
 <tr valign="top">
@@ -946,7 +946,7 @@ Some fields, including those on the login and registration forms, have the <code
 <td>
 Generally, all text and images of text supplied by us on the pages of this product have a contrast ratio of at least 4.5:1.
 <br><br>
-Some placeholder text (e.g. on payment pages) may have insufficient contrast. We are actively working to find and repair these problems. 
+Some placeholder text (e.g. on payment pages) may have insufficient contrast. We are actively working to find and repair these problems.
 <br><br>
 Third party advertising scripts may inject content with insufficient contrast.
 </td>
@@ -1000,7 +1000,7 @@ Third party scripts (for example advertisements) may inject non-responsive conte
 <td>
 Outside of editoral content managed by content management system (CMS), published books and papers, and third party scripts, the pages of this product do not use images of text to convey information except in the case of <a href="https://www.w3.org/WAI/WCAG21/Understanding/images-of-text.html">logotypes</a> (considered essential per WCAG 2.1) or when the image is <a href="https://www.w3.org/TR/WCAG21/#dfn-pure-decoration">pure decoration</a>.
 <br><br>
-CMS content and published books and papers may include complex images that contain images of text. In most cases these images are used to supplement the text content they appear alongside. In some cases (e.g. charts, graphs, or maps, among others), the text content presented alongside may be insufficient to explain the contents of the image. 
+CMS content and published books and papers may include complex images that contain images of text. In most cases these images are used to supplement the text content they appear alongside. In some cases (e.g. charts, graphs, or maps, among others), the text content presented alongside may be insufficient to explain the contents of the image.
 <br><br>
 Third party advertising scripts may inject images containing images of text.
 </td>
@@ -1043,7 +1043,7 @@ Third party scripts (e.g. advertising, customer services widgets) may inject con
 </td>
 <td>Partially Supports</td>
 <td>
-The visual presentation of User Interface Components in this product have a contrast ratio of at least 3:1 against adjacent color(s). 
+The visual presentation of User Interface Components in this product have a contrast ratio of at least 3:1 against adjacent color(s).
 <br><br>
 Graphical Objects (e.g. charts, graphs, or maps, among others) supplied by authors may have inadequate contrast.
 <br><br>
@@ -1137,7 +1137,7 @@ Third party content (e.g. advertising, customer services widgets) may inject ele
 <td>
 Our document structure is semantically marked up using headings to create a sequential hierarchy of content. Sometimes headings or labels may be visually hidden but available to Assistive Technologies.
 <br><br>
-Nature magazine and a limited number of journals publish editorial content from a content management system (CMS). Content generated by CMS may occasionally lack appropriate headings (e.g. using bold text as implicit headings instead of semantically-marked up heading elements). 
+Nature magazine and a limited number of journals publish editorial content from a content management system (CMS). Content generated by CMS may occasionally lack appropriate headings (e.g. using bold text as implicit headings instead of semantically-marked up heading elements).
 <br><br>
 Other third party scripts, including survey or customer services widgets, may inject content with inadequate or inappropriate headings or labels. When we become aware of deficiencies, we contact third party suppliers to request repairs.
 </td>
@@ -1167,7 +1167,7 @@ Generally, we provide high-visibility yellow focus rings on all focusable elemen
 <br><br>
 Some pages (e.g. some payment or “my account” pages) use default focus rings only. On some of these pages, the default focus ring has been removed from input elements and replaced with a different focus style that provides inadequate visibility. Some components on payment pages remove focus styles. We are actively working to repair these problems; the high-visibility focus ring across the majority of Nature.com is intended to be the default.
 <br><br>
-Pages that use older designs may use default focus rings only. 
+Pages that use older designs may use default focus rings only.
 <br><br>
 Third party scripts, including advertising, may inject components that remove focus styles.
 </td>
@@ -1194,7 +1194,7 @@ Third party scripts, including advertising, may inject components that remove fo
 <td>Does Not Support</td>
 <td>Language of Parts is not applicable for the majority of this content. All first-party components on the pages of this product that are part of dynamic templates are written in English.
 <br><br>
-Editorial content or published papers may be written in or include text in languages other than English. This content is not marked up with a separate <code>lang</code> attribute. 
+Editorial content or published papers may be written in or include text in languages other than English. This content is not marked up with a separate <code>lang</code> attribute.
 <br><br>
 Third party scripts may inject components with non-English text - for example a targeted advertisement or file presented in a file viewer (e.g. Figshare) may use a different language to the main document. These may not be marked up with a separate <code>lang</code> attribute.
 <br><br>
@@ -1224,7 +1224,7 @@ We currently have no method of confirming the inclusion of appropriate lang attr
 <td>
 Navigational mechanisms that are repeated on multiple Web pages within the Nature.com website occur in the same relative order each time they are repeated. Although some older archive content on the Nature.com website may be rendered in older design templates, the navigation of each of these sets of pages is internally consistent.
 <br><br>
-Pages that deal with sensitive information (including payment pages and "my account" pages) have intentionally been made more simple in design, and do not share the same navigation system as the main site. The navigation of each of these sets of pages is internally consistent. 
+Pages that deal with sensitive information (including payment pages and "my account" pages) have intentionally been made more simple in design, and do not share the same navigation system as the main site. The navigation of each of these sets of pages is internally consistent.
 </td>
 </tr>
 <tr valign="top">
@@ -1250,7 +1250,7 @@ Pages that deal with sensitive information (including payment pages and "my acco
 <td>
 Components that have the same functionality within a set of Web pages are identified consistently. Although some older archive content on the Nature.com website may be rendered in older design templates, the identification of components in each of these sets of pages is internally consistent.
 <br><br>
-Pages that deal with sensitive information (including payment pages and "my account" pages) have intentionally been made more simple in design. The presentation of each of these sets of pages is internally consistent, and the tasks performed are unlike those performed elsewhere on the site. 
+Pages that deal with sensitive information (including payment pages and "my account" pages) have intentionally been made more simple in design. The presentation of each of these sets of pages is internally consistent, and the tasks performed are unlike those performed elsewhere on the site.
 </td>
 </tr>
 <tr valign="top">
@@ -1274,7 +1274,7 @@ Pages that deal with sensitive information (including payment pages and "my acco
 </ul></td>
 <td>Partially Supports</td>
 <td>
-Where user input errors are automatically detected by our own software, those errors are identified with warning text adjacent to the input field. Unless it would present a risk to security, the warning text describes the error and what the user should do to correct it. 
+Where user input errors are automatically detected by our own software, those errors are identified with warning text adjacent to the input field. Unless it would present a risk to security, the warning text describes the error and what the user should do to correct it.
 <br><br>
 Third party scripts including the Disqus commenting widget, or other widgets that accept user input, may automatically detect errors but fail to present the errors to users in ways that they can perceive. They may rely on visual characteristics alone to indicate user input errors, or place error text in locations that are difficult for screen reader users to access. When we become aware of deficiencies, we contact third party suppliers to request repairs.
 </td>
@@ -1468,7 +1468,7 @@ Data tables in dynamic templates are rare, but where they do appear, they are ma
 <td headers="502-services chap-5-criteria">502.3.6 Label Relationships</td>
 <td headers="502-services chap-5-conformance">Supports</td>
 <td headers="502-services chap-5-remarks">
-The pages in this product use labels on components that require user input. 
+The pages in this product use labels on components that require user input.
 <br><br>
 See WCAG sections <a href="#headings-and-labels">2.4.6 Headings and Labels</a> and <a href="#labels-or-instructions">3.3.2 Labels or Instructions</a> for further detail.
 </td>
@@ -1488,7 +1488,7 @@ See WCAG section <a href="#info-and-relationships">1.3.1 Info and Relationships<
 <td headers="502-services chap-5-remarks">
 The pages of this product use standard plain text in HTML.
 <br><br>
-Original research or editorial content may contain images of text without adequate programmatically determinable alternatives. 
+Original research or editorial content may contain images of text without adequate programmatically determinable alternatives.
 </td>
 </tr>
 <tr>
@@ -1532,7 +1532,7 @@ See WCAG sections <a href="#use-of-color">1.4.1 Use of Color</a> and <a href="#f
 <td headers="502-services chap-5-remarks">
 The pages of this product use standard HTML and WAI-ARIA attributes to describe the identity, operation, and state of user interface elements to Assistive Technologies.
 <br><br>
-Rarely, components may omit or misuse WAI-ARIA attributes in a way that prevents users of some Assistive Technologies from being able to percieve changes in state. We are actively working to find and repair these problems. 
+Rarely, components may omit or misuse WAI-ARIA attributes in a way that prevents users of some Assistive Technologies from being able to percieve changes in state. We are actively working to find and repair these problems.
 <br><br>
 Some third party scripts may inject content that fails to notify users of changes in state.
 <br><br>
@@ -1680,11 +1680,11 @@ Notes: This report covers accessibility conformance for the web product and does
 
 Notes: This product supports standard web Assistive Technologies and is therefore not subject to the Closed Functionality criteria described in this chapter.
 
-### Chapter [6: ICT with Two-Way Voice Communication](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=30) 
+### Chapter [6: ICT with Two-Way Voice Communication](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=30)
 
 Notes: This product does not offer two-way voice communication and is therefore not subject to the requirements of this chapter.
 
-### Chapter [7: ICT with Video Capabilities](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=35) 
+### Chapter [7: ICT with Video Capabilities](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=35)
 
 Notes:
 
@@ -1762,7 +1762,7 @@ Notes: This product does not include non-web documents and is therefore not subj
 </thead>
 <tbody>
 <tr>
-<th scope="column" colspan="3" id="11-gen">11.0 General (informative)</th> 
+<th scope="column" colspan="3" id="11-gen">11.0 General (informative)</th>
 </tr>
 <td headers="11-gen chap-11-criteria">11.1.1 through 11.4.1.3</td>
 <td headers "11-gen chap-11-conformance">See <a ref="#WCAG">WCAG 2.0</a> Section</td>

--- a/nature.md
+++ b/nature.md
@@ -7,7 +7,7 @@
 Nature.com publishes peer-reviewed research, reviews and news across a number of journals. This report refers entirely to the accessibility of editorial, journal, and magazine web documents published at the top level domain of <a href="http://www.nature.com">www.nature.com</a>, including informational pages, and to all web documents found at idp.nature.com and payment.nature.com (for account management and subscription and payment management respectively).  
 **Contact information**: Please contact your Institutional Sales representative.  
 **Notes**:  
-**Evaluation Methods Used**: Conformance to the listed accessibility standards has been evaluated by Springer Nature's dedicated Accessibility Specialists. We use a combination of static analysis tools (including but not limited to [axe by Deque](https://www.deque.com/axe/), [WAVE by WebAIM](https://wave.webaim.org/extension/), and all of the tools described in our [Frontend Playbook's Accessibility Guide](https://github.com/springernature/frontend-playbook/blob/main/accessibility/tools.md)). Our manual testing uses [WCAG-EM](https://www.w3.org/WAI/test-evaluate/conformance/wcag-em/) as its base strategy, and further details are also described in our Frontend Playbook under the "Manual testing" and "Assistive technology" sections. 
+**Evaluation Methods Used**: Conformance to the listed accessibility standards has been evaluated by Springer Nature's dedicated Accessibility Specialists. We use a combination of static analysis tools (including but not limited to [axe by Deque](https://www.deque.com/axe/), [WAVE by WebAIM](https://wave.webaim.org/extension/), and all of the tools described in our [Frontend Playbook's Accessibility Guide](https://github.com/springernature/frontend-playbook/blob/main/accessibility/tools.md)). Our manual testing uses [WCAG-EM](https://www.w3.org/WAI/test-evaluate/conformance/wcag-em/) as its base strategy, and further details are also described in our Frontend Playbook under the "Manual testing" and "Assistive technology" sections.
 
 
 ## Applicable Standards/Guidelines
@@ -47,7 +47,7 @@ The terms used in the Conformance Level information are defined as follows:
 - **Partially Supports**: Some functionality of the product does not meet the criterion.
 - **Does Not Support**: The majority of product functionality does not meet the criterion.
 - **Not Applicable**: The criterion is not relevant to the product.
-- **Not Evaluated**: The product has not been evaluated against the criterion. This can be used only in WCAG 2.1 Level AAA.
+- **Not Evaluated**: The product has not been evaluated against the criterion. This can be used only in WCAG 2.x Level AAA.
 
 ## WCAG 2.1 Report
 

--- a/springerlink.md
+++ b/springerlink.md
@@ -6,7 +6,7 @@
 **Product Description**: SpringerLink provides researchers with access to scientific documents from journals, books, series, protocols, collections, reference works and proceedings. This report refers entirely to the accessibility of all web documents published at the subdomains link.springer.com and rd.springer.com (both subdomains are referred to as link.springer.com throughout this report), and supporting informational pages such as journal homepages located at the top level domain, springer.com. Also included are all web documents included in the purchasing and subscription process, found at order.springer.com.
  **Contact information**: Please contact your Institutional Sales representative.   
  **Notes**:   
-**Evaluation Methods Used**: Conformance to the listed accessibility standards has been evaluated by Springer Nature's dedicated Accessibility Specialists. We use a combination of static analysis tools (including but not limited to [axe by Deque](https://www.deque.com/axe/), [WAVE by WebAIM](https://wave.webaim.org/extension/), and all of the tools described in our [Frontend Playbook's Accessibility Guide](https://github.com/springernature/frontend-playbook/blob/main/accessibility/tools.md)). Our manual testing uses [WCAG-EM](https://www.w3.org/WAI/test-evaluate/conformance/wcag-em/) as its base strategy, and further details are also described in our Frontend Playbook under the "Manual testing" and "Assistive technology" sections. 
+**Evaluation Methods Used**: Conformance to the listed accessibility standards has been evaluated by Springer Nature's dedicated Accessibility Specialists. We use a combination of static analysis tools (including but not limited to [axe by Deque](https://www.deque.com/axe/), [WAVE by WebAIM](https://wave.webaim.org/extension/), and all of the tools described in our [Frontend Playbook's Accessibility Guide](https://github.com/springernature/frontend-playbook/blob/main/accessibility/tools.md)). Our manual testing uses [WCAG-EM](https://www.w3.org/WAI/test-evaluate/conformance/wcag-em/) as its base strategy, and further details are also described in our Frontend Playbook under the "Manual testing" and "Assistive technology" sections.
 
 ## Applicable Standards/Guidelines
 
@@ -45,7 +45,7 @@ The terms used in the Conformance Level information are defined as follows:
 - **Partially Supports**: Some functionality of the product does not meet the criterion.
 - **Does Not Support**: The majority of product functionality does not meet the criterion.
 - **Not Applicable**: The criterion is not relevant to the product.
-- **Not Evaluated**: The product has not been evaluated against the criterion. This can be used only in WCAG 2.1 Level AAA.
+- **Not Evaluated**: The product has not been evaluated against the criterion. This can be used only in WCAG 2.x Level AAA.
 
 ## WCAG 2.1 Report
 

--- a/springerlink.md
+++ b/springerlink.md
@@ -1418,7 +1418,7 @@ Pages located at order.springer.com rely solely on built-in browser error checki
 
 ### Table 3: Success Criteria, Level AAA
 
-Notes: This product has not been evaluated for WCAG 2.1 Level AAA conformance.
+Notes: This product has not been evaluated for WCAG 2.x Level AAA conformance.
 
 ## Revised Section 508 Report
 
@@ -1863,7 +1863,7 @@ Notes: This product does not include non-web documents and is therefore not subj
  </tr>
 <tr>
 <td headers="11-gen chap-11-criteria">11.1.1 through 11.4.1.3</td>
-<td headers="11-gen chap-11-conformance">See <a ref="#WCAG">WCAG 2.0</a> Section</td>
+<td headers="11-gen chap-11-conformance">See <a ref="#WCAG">WCAG 2.x</a> Section</td>
 <td headers="11-gen chap-11-remarks">See information in WCAG section</td>
 </tr>
 <tr>

--- a/springerlink.md
+++ b/springerlink.md
@@ -1,4 +1,4 @@
-# SpringerLink Accessibility Conformance Report International Edition 
+# SpringerLink Accessibility Conformance Report International Edition
 (Based on VPAT® Version 2.4Rev)
 
 **Report Date**: 22nd June 2022  
@@ -6,7 +6,7 @@
 **Product Description**: SpringerLink provides researchers with access to scientific documents from journals, books, series, protocols, collections, reference works and proceedings. This report refers entirely to the accessibility of all web documents published at the subdomains link.springer.com and rd.springer.com (both subdomains are referred to as link.springer.com throughout this report), and supporting informational pages such as journal homepages located at the top level domain, springer.com. Also included are all web documents included in the purchasing and subscription process, found at order.springer.com.
  **Contact information**: Please contact your Institutional Sales representative.   
  **Notes**:   
-**Evaluation Methods Used**: Conformance to the listed accessibility standards has been evaluated by Springer Nature's dedicated Accessibility Specialists. We use a combination of static analysis tools (including but not limited to Axe, WAVE, and all of the tools described in our [Frontend Playbook's Accessibility Guide](https://github.com/springernature/frontend-playbook/blob/main/accessibility/tools.md)). Additionally, we perform manual testing (also described in our Frontend Playbook under the "Manual testing" and "Assistive technology" sections).  
+**Evaluation Methods Used**: Conformance to the listed accessibility standards has been evaluated by Springer Nature's dedicated Accessibility Specialists. We use a combination of static analysis tools (including but not limited to [axe by Deque](https://www.deque.com/axe/), [WAVE by WebAIM](https://wave.webaim.org/extension/), and all of the tools described in our [Frontend Playbook's Accessibility Guide](https://github.com/springernature/frontend-playbook/blob/main/accessibility/tools.md)). Our manual testing uses [WCAG-EM](https://www.w3.org/WAI/test-evaluate/conformance/wcag-em/) as its base strategy, and further details are also described in our Frontend Playbook under the "Manual testing" and "Assistive technology" sections. 
 
 ## Applicable Standards/Guidelines
 
@@ -89,7 +89,7 @@ Tables 1 and 2 also document conformance with:
 <td>
 Most in-line images supplied in article content provide alternative text, or descriptions, or figure captions. We are working towards full support.  
 <br><br>
-Some images, such as icons on user interface elements, are known to have inadequate or missing text alternatives. We are actively working to find and repair these problems. 
+Some images, such as icons on user interface elements, are known to have inadequate or missing text alternatives. We are actively working to find and repair these problems.
 <br><br>
 We mark up some images so that they can be ignored by Assistive Technologies if they are <a href="https://www.w3.org/TR/WCAG21/#dfn-pure-decoration"><i>pure decoration</i></a> (as defined by WCAG 2.1).
 <br><br>
@@ -117,9 +117,9 @@ Third party scripts may inject non-text content without text alternatives, or wi
 </ul></td>
 <td>Partially Supports</td>
 <td>
-SpringerLink offers multimedia content through the third party MovingImage platform, or as downloadable video files in various formats. 
+SpringerLink offers multimedia content through the third party MovingImage platform, or as downloadable video files in various formats.
 <br><br>
-Video-only and audio-only content are generally used to support existing text-based content. 
+Video-only and audio-only content are generally used to support existing text-based content.
 <br><br>
 We currently have no method of confirming the inclusion of adequate media alternatives or transcripts.
 </td>
@@ -145,11 +145,11 @@ We currently have no method of confirming the inclusion of adequate media altern
 </ul></td>
 <td>Partially supports</td>
 <td>
-SpringerLink offers multimedia content through the third party MovingImage platform, or as downloadable video files in various formats. 
+SpringerLink offers multimedia content through the third party MovingImage platform, or as downloadable video files in various formats.
 <br><br>
-Captions and/or transcripts maybe be provided for some pre-recorded content in journals, books, series, protocols, reference works or proceedings. We currently have no method of confirming the inclusion of transcripts or captions. 
+Captions and/or transcripts maybe be provided for some pre-recorded content in journals, books, series, protocols, reference works or proceedings. We currently have no method of confirming the inclusion of transcripts or captions.
 <br><br>
-"Springer Nature Video" learning content published at link.springer.com/video uses the third party MovingImage platform. Both captions and transcripts are available. 
+"Springer Nature Video" learning content published at link.springer.com/video uses the third party MovingImage platform. Both captions and transcripts are available.
 </td>
 </tr>
 <tr id="audio-description-or-media-alternative-prerecorded" valign="top">
@@ -175,7 +175,7 @@ Captions and/or transcripts maybe be provided for some pre-recorded content in j
 <td>
 SpringerLink offers multimedia content through the third party MovingImage platform, or as downloadable video files in various formats.
 <br><br>
-Audio description is not generally used across our content, but some media may be presented alongside media alternatives such as text descriptions of video content. 
+Audio description is not generally used across our content, but some media may be presented alongside media alternatives such as text descriptions of video content.
 <br><br>
 We currently have no method of confirming the inclusion of adequate media alternatives.
 </td>
@@ -201,17 +201,17 @@ We currently have no method of confirming the inclusion of adequate media altern
 </ul></td>
 <td>Partially Supports</td>
 <td>
-The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design. 
+The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design.
 <br><br>
-Pages rendered in the <strong>older</strong> design (currently journals, and ancillary pages such as search, indexes, and account management) may use unsemantic markup, including inadequate, misleading, or incorrectly-applied landmarks. Some UI controls (e.g. "next" and "previous" pagination controls on search results pages) lack accessible names. Pages may omit level one headings. 
+Pages rendered in the <strong>older</strong> design (currently journals, and ancillary pages such as search, indexes, and account management) may use unsemantic markup, including inadequate, misleading, or incorrectly-applied landmarks. Some UI controls (e.g. "next" and "previous" pagination controls on search results pages) lack accessible names. Pages may omit level one headings.
 <br><br>
 On pages rendered in the <strong>newer</strong> design (currently articles, chapters, books, book series, reference works, reference work entries, and collections), we generally use progressive enhancement techniques and semantically-correct markup so that information, structure, and relationships can be understood independently of presentation.
 <br><br>
-We make use of WAI-ARIA roles to support landmarks, and use WAI-ARIA roles and properties when required for more complex functionality such as popup menus and dialogs. 
+We make use of WAI-ARIA roles to support landmarks, and use WAI-ARIA roles and properties when required for more complex functionality such as popup menus and dialogs.
 <br><br>
-Some complex functionality may omit required WAI-ARIA roles, states, or attributes, or misuse WAI-ARIA markup and techniques. We are actively working to find and repair these problems. 
+Some complex functionality may omit required WAI-ARIA roles, states, or attributes, or misuse WAI-ARIA markup and techniques. We are actively working to find and repair these problems.
 <br><br>
-The SpringerLink checkout process pages found at order.springer.com omit or use inappropriate headings and heading levels, including the use of unsemantic headings for visual effect. Multiple landmarks of the same type without unique labels are also found on these pages. The pages use form fields that rely solely on built-in browser error checking, which can lead to error messages being unavailable for users with older browser technology, or Assistive Technology that doesn't support these features. 
+The SpringerLink checkout process pages found at order.springer.com omit or use inappropriate headings and heading levels, including the use of unsemantic headings for visual effect. Multiple landmarks of the same type without unique labels are also found on these pages. The pages use form fields that rely solely on built-in browser error checking, which can lead to error messages being unavailable for users with older browser technology, or Assistive Technology that doesn't support these features.
 <br><br>
 Third party scripts may inject content with incorrect or absent information about structure and relationships. These may include content in advertising scripts and the Freshdesk customer services widget, among others.
 </td>
@@ -265,9 +265,9 @@ The pages found at link.springer.com generally do not depend solely on sensory c
 <br><br>
 We make use of graphical icons on controls. Adjacent visible text labels or WAI-ARIA labels are generally provided.
 <br><br>
-Some icons (e.g. "next" and "previous" pagination controls on search results pages) in the <strong>older</strong> design (currently journals, and ancillary pages such as search, indexes, and account management) lack accessible names. Users who are unable to perceive these icons by their sensory characteristics may be unable to use these controls. We are in the process of transferring all content from the older design to the newer design, which will remove the reliance on sensory characteristics for understanding. 
+Some icons (e.g. "next" and "previous" pagination controls on search results pages) in the <strong>older</strong> design (currently journals, and ancillary pages such as search, indexes, and account management) lack accessible names. Users who are unable to perceive these icons by their sensory characteristics may be unable to use these controls. We are in the process of transferring all content from the older design to the newer design, which will remove the reliance on sensory characteristics for understanding.
 <br><br>
-Some complex images in journals, books, series, protocols, reference works and proceedings may rely on sensory characteristics to be understood. Examples may include images of charts, graphs, diagrams, or maps. Generally, these images are used to supplement text content. 
+Some complex images in journals, books, series, protocols, reference works and proceedings may rely on sensory characteristics to be understood. Examples may include images of charts, graphs, diagrams, or maps. Generally, these images are used to supplement text content.
 <br><br>
 The Freshdesk customer services widget uses controls without accessible names. We are actively working to solve this problem. Additionally, we have provided alternate means of accessing customer services on our "Contact Us" page, including a contact email address, a support ticket system, and helpdesk telephone numbers.
 </td>
@@ -297,7 +297,7 @@ Colour alone is generally not used to convey information in the pages of this pr
 <br><br>
 Links and icons may use colour to indicate hover or active states. These are supplemented with visible focus rings and/or background colours and/or text decoration underlines and/or luminosity differences per WAI techniques <a href="https://www.w3.org/WAI/WCAG21/Techniques/general/G183">G183</a> and <a href="https://www.w3.org/WAI/WCAG21/Techniques/css/C15">C15</a>.
 <br><br>
-Some complex images in journals, books, series, protocols, reference works and proceedings may rely on colour as the only visual means of understanding information. Examples may include images of charts, graphs, diagrams or maps. Generally, these images are used to supplement text content. 
+Some complex images in journals, books, series, protocols, reference works and proceedings may rely on colour as the only visual means of understanding information. Examples may include images of charts, graphs, diagrams or maps. Generally, these images are used to supplement text content.
 </td>
 </tr>
 <tr id="audio-control" valign="top">
@@ -321,11 +321,11 @@ Some complex images in journals, books, series, protocols, reference works and p
 </ul></td>
 <td>Partially Supports</td>
 <td>
-Content supplied by us does not play automatically. 
+Content supplied by us does not play automatically.
 <br><br>
-All video with audio hosted through the third party MovingImage platform has a mechanism for pausing, stopping, and controlling volume. 
+All video with audio hosted through the third party MovingImage platform has a mechanism for pausing, stopping, and controlling volume.
 <br><br>
-We do not support the playing of audio-only directly on our pages. Audio files hosted by us are supplied as downloadable files only, for use in the users' own media player. 
+We do not support the playing of audio-only directly on our pages. Audio files hosted by us are supplied as downloadable files only, for use in the users' own media player.
 <br><br>
 Third party advertisements may load video and audio that automatically starts, and may not provide adequate controls for pausing, stopping, and/or controlling volume. When we become aware of active advertisements with these problems, we immediately take steps to remove those advertisements from our pages.
 </td>
@@ -353,23 +353,23 @@ Third party advertisements may load video and audio that automatically starts, a
 <td>
 The majority of components in the SpringerLink website can be navigated by keyboard alone. We also provide skip links for bypassing repetitive navigation elements.
 <br><br>
-Mouse-dependent event handlers are used to display additional information relating to images displayed on the homepage and to icons in search results, which may make the purpose of these graphics difficult to discern for keyboard users. We are actively working to repair these problems. 
+Mouse-dependent event handlers are used to display additional information relating to images displayed on the homepage and to icons in search results, which may make the purpose of these graphics difficult to discern for keyboard users. We are actively working to repair these problems.
 <br><br>
-Mouse-dependent event handlers are used to display detailed information about the meaning of preview-only content on advanced search pages. We are actively working to repair these problems. 
+Mouse-dependent event handlers are used to display detailed information about the meaning of preview-only content on advanced search pages. We are actively working to repair these problems.
 <br><br>
 Content contained inside tab interfaces (e.g. tables of contents in Books) cannot be operated by keyboard alone. We are actively working to repair these problems.  
 <br><br>
-SpringerLink offers multimedia content through the third party MovingImage platform, or as downloadable video files in various formats. 
+SpringerLink offers multimedia content through the third party MovingImage platform, or as downloadable video files in various formats.
 
 Video content located at link.springer.com/video can generally be operated without the use of a mouse, but some video functions (including turning on closed captions) cannot be operated by keyboard alone. Additionally, keyboard users are unable to toggle between the "details" and "transcript" tabs below the video. We are actively working to repair these problems.  
 
-Video content elsewhere (e.g. chapters or articles) cannot currently be operated with the keyboard. We are actively working to repair this problem. 
+Video content elsewhere (e.g. chapters or articles) cannot currently be operated with the keyboard. We are actively working to repair this problem.
 <br><br>
 Third party advertising scripts may inject content that cannot be interacted with easily or at all by keyboard.
 <br><br>
-The Freshdesk customer services widget cannot be interacted with easily by keyboard alone. We are actively working to solve this problem. Additionally, we have provided alternate means of accessing customer services on our "Contact Us" page, including a contact email address, a support ticket system, and helpdesk telephone numbers. 
+The Freshdesk customer services widget cannot be interacted with easily by keyboard alone. We are actively working to solve this problem. Additionally, we have provided alternate means of accessing customer services on our "Contact Us" page, including a contact email address, a support ticket system, and helpdesk telephone numbers.
 <br><br>
-When we become aware of deficiencies, we contact third party suppliers to request repairs. Additionally, where possible, we aim to provide equivalent alternatives to problematic content. 
+When we become aware of deficiencies, we contact third party suppliers to request repairs. Additionally, where possible, we aim to provide equivalent alternatives to problematic content.
 </td>
 </tr>
 <tr id="no-keyboard-trap" valign="top">
@@ -393,7 +393,7 @@ When we become aware of deficiencies, we contact third party suppliers to reques
 </ul></td>
 <td>Partially Supports</td>
 <td>
-Keyboard trapping inside components on SpringerLink pages is rare, and in most cases is managed appropriately, allowing focus to be moved away from any component using standard keystrokes (<kbd>tab</kbd>, <kbd>shift</kbd>, <kbd>esc</kbd>). 
+Keyboard trapping inside components on SpringerLink pages is rare, and in most cases is managed appropriately, allowing focus to be moved away from any component using standard keystrokes (<kbd>tab</kbd>, <kbd>shift</kbd>, <kbd>esc</kbd>).
 <br><br>
 Modal dialogs (including those generated by third party scripts) may trap focus and provide inadequate methods of escaping. When we become aware of deficiencies, we actively work on repairs of our own, and with third party vendors where required.
 </td>
@@ -459,9 +459,9 @@ Modal dialogs (including those generated by third party scripts) may trap focus 
 </ul></td>
 <td>Partially Supports</td>
 <td>
-Any moving, blinking or scrolling content on SpringerLink pages generally does not start automatically, and is complemented by controls that allow users to pause or otherwise stop the content. Moving images in the form of gifs may not meet this criterion. 
+Any moving, blinking or scrolling content on SpringerLink pages generally does not start automatically, and is complemented by controls that allow users to pause or otherwise stop the content. Moving images in the form of gifs may not meet this criterion.
 <br><br>
-Third party advertising scripts may inject content that automatically moves or blinks and lasts more than five seconds, without providing a mechanism to pause, stop, or hide that content. 
+Third party advertising scripts may inject content that automatically moves or blinks and lasts more than five seconds, without providing a mechanism to pause, stop, or hide that content.
 </td>
 </tr>
 <tr id="three-flashes-or-below-threshold" valign="top">
@@ -535,7 +535,7 @@ Pages located at order.springer.com have landmarks present. Some are duplicated 
 <td>
 SpringerLink pages mostly have unique page titles that describe the purpose of the page.
 <br><br>
-Where multiple versions of the same content exist (e.g. in original research with a separate updated version), the page titles do not differentiate between versions. 
+Where multiple versions of the same content exist (e.g. in original research with a separate updated version), the page titles do not differentiate between versions.
 </td>
 </tr>
 <tr id="focus-order" valign="top">
@@ -559,17 +559,17 @@ Where multiple versions of the same content exist (e.g. in original research wit
 </ul></td>
 <td>Partially Supports</td>
 <td>
-The meaning and/or operation of content on SpringerLink is generally unaffected by focus order. 
+The meaning and/or operation of content on SpringerLink is generally unaffected by focus order.
 <br><br>
-The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design. 
+The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design.
 <br><br>
-Some pages rendered in the <strong>older</strong> design may contain components where some items in the focus order do not match the visual order (for example the "date published" filtering on search results pages). 
+Some pages rendered in the <strong>older</strong> design may contain components where some items in the focus order do not match the visual order (for example the "date published" filtering on search results pages).
 <br><br>
 On pages rendered in the <strong>newer</strong> design (currently articles, chapters, books, book series, reference works, reference work entries, and collections), the focus order of page content matches the visual order.
 <br><br>
-Form labels located at order.springer.com are placed after their associated form fields in the source order, which does not match the visual order. Screen reader users moving through the form element by element may access the label after the input field instead of before, though all input fields are correctly associated with their labels. 
+Form labels located at order.springer.com are placed after their associated form fields in the source order, which does not match the visual order. Screen reader users moving through the form element by element may access the label after the input field instead of before, though all input fields are correctly associated with their labels.
 <br><br>
-Third party scripts including advertising scripts or customer services widgets (among others), may inject content where the focus order does not match the visual order. The operation and meaning of these components should be unaffected by the focus order. 
+Third party scripts including advertising scripts or customer services widgets (among others), may inject content where the focus order does not match the visual order. The operation and meaning of these components should be unaffected by the focus order.
 </td>
 </tr>
 <tr id="link-purpose-in-context" valign="top">
@@ -597,7 +597,7 @@ Generally, the purpose of each link found at link.springer.com can be determined
 <br><br>
 When citing references in articles, the link text contains only the year of the reference's publication. This may provide inadequate context for screen reader users. A title attribute is provided on these links, but the title attribute may not be made available by all Assistive Technologies.
 <br><br>
-In articles, anchor links that refer to same-page supplementary figures or tables use only the number of the supplementary material as their link text (e.g. "Figure 1" will be linked to only by the number "1"). This is likely to be insufficient context for screen reader users. 
+In articles, anchor links that refer to same-page supplementary figures or tables use only the number of the supplementary material as their link text (e.g. "Figure 1" will be linked to only by the number "1"). This is likely to be insufficient context for screen reader users.
 <br><br>
 Third party scripts including advertising scripts or customer services widgets (among others), may inject content that includes links with no accessible text, or poorly-named accessible text. When we become aware of deficiencies, we contact third party suppliers to request repairs or are actively seeking solutions. Additionally, where possible, we aim to provide equivalent alternatives to problematic content.
 </td>
@@ -655,11 +655,11 @@ Third party scripts including advertising scripts or customer services widgets (
 </td>
 <td>Partially Supports</td>
 <td>
-In most cases where controls contain visible text, that text is also the label for the control, with limited exceptions. 
+In most cases where controls contain visible text, that text is also the label for the control, with limited exceptions.
 <br><br>
 Images of product covers (e.g. journals, books displayed on the homepage of link.springer.com) used as links may contain text that does not meet this criterion. On the homepage, these images are supplemented with visible text labels (but the text is triggered by mouse-dependent event handlers, and their visibility cannot be toggled by the keyboard).
 <br><br>
-In pages rendered in all designs, some controls without text but with high recognisability (e.g. "next" and "previous" pagination controls on search results pages, the "play" button on the video player at link.springer.com/video) have inadequate or absent accessible names. 
+In pages rendered in all designs, some controls without text but with high recognisability (e.g. "next" and "previous" pagination controls on search results pages, the "play" button on the video player at link.springer.com/video) have inadequate or absent accessible names.
 </td>
 </tr>
 <tr id="motion-actuation" valign="top">
@@ -701,11 +701,11 @@ In pages rendered in all designs, some controls without text but with high recog
 </ul></td>
 <td>Partially Supports</td>
 <td>
-The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design. 
+The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design.
 <br><br>
-Pages rendered in the <strong>older</strong> design (currently journals, and ancillary pages such as search, indexes, and account management) may be switched by the user between English and German. These pages use the language attribute on the HTML element to indicate which language is being used as the default language of a page. 
+Pages rendered in the <strong>older</strong> design (currently journals, and ancillary pages such as search, indexes, and account management) may be switched by the user between English and German. These pages use the language attribute on the HTML element to indicate which language is being used as the default language of a page.
 <br><br>
-Pages rendered in the <strong>newer</strong> design (currently articles, chapters, books, book series, reference works, reference work entries, and collections) are presented in English only, with the correct language attribute applied to the HTML element. 
+Pages rendered in the <strong>newer</strong> design (currently articles, chapters, books, book series, reference works, reference work entries, and collections) are presented in English only, with the correct language attribute applied to the HTML element.
 </td>
 </tr>
 <tr id="on-focus" valign="top">
@@ -773,13 +773,13 @@ Pages rendered in the <strong>newer</strong> design (currently articles, chapter
 </ul></td>
 <td>Partially Supports</td>
 <td>
-Where user input errors are automatically detected by our own software, those errors are identified with warning text adjacent to the input field. We do not rely on visual characteristics alone (e.g. colour) to indicate user input errors. 
+Where user input errors are automatically detected by our own software, those errors are identified with warning text adjacent to the input field. We do not rely on visual characteristics alone (e.g. colour) to indicate user input errors.
 <br><br>
 In some parts of the site, we additionally use an <code>aria-describedby</code> property to associate error messages with invalid fields.
 <br><br>
-User account pages located at link.springer.com/account use unsemantic, unassociated, label elements to mark up errors. 
+User account pages located at link.springer.com/account use unsemantic, unassociated, label elements to mark up errors.
 <br><br>
-Pages located at order.springer.com rely solely on built-in browser error checking, and do not identify errors in text. Some users with and without Assistive Technology may be unable to access these error states. 
+Pages located at order.springer.com rely solely on built-in browser error checking, and do not identify errors in text. Some users with and without Assistive Technology may be unable to access these error states.
 </td>
 </tr>
 <tr id="labels-or-instructions" valign="top">
@@ -803,13 +803,13 @@ Pages located at order.springer.com rely solely on built-in browser error checki
 </ul></td>
 <td>Partially Supports</td>
 <td>
-The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design. 
+The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design.
 <br><br>
 Pages rendered in the <strong>older</strong> design (currently journals, and ancillary pages such as search, indexes, and account management) generally display visible and appropriately associated labels for input fields. Exceptions include the pagination number field on advanced search results pages and in the main search component in the page banner, both of which omit any label or WAI-ARIA description, and use only placeholder text as instruction. We are actively working to find and repair these problems.  
 <br><br>
-Pages rendered in the <strong>newer</strong> design (currently articles, chapters, books, book series, reference works, reference work entries, and collections) generally display visible and appropriately associated labels for input fields. 
+Pages rendered in the <strong>newer</strong> design (currently articles, chapters, books, book series, reference works, reference work entries, and collections) generally display visible and appropriately associated labels for input fields.
 <br><br>
-Instructions such as those that explain mandatory fields may be absent or only present at the end of forms. (e.g. some payment information pages). Additional instructions for specific input fields may not be adequately associated (e.g. with <code>aria-describedby</code>) with the fields they describe. We are actively working to find and repair these problems. 
+Instructions such as those that explain mandatory fields may be absent or only present at the end of forms. (e.g. some payment information pages). Additional instructions for specific input fields may not be adequately associated (e.g. with <code>aria-describedby</code>) with the fields they describe. We are actively working to find and repair these problems.
 </td>
 </tr>
 <tr id="parsing" valign="top">
@@ -836,14 +836,14 @@ Instructions such as those that explain mandatory fields may be absent or only p
 Most of the pages found at link.springer.com generally use semantically-correct markup that meets the HTML5 specification for interface elements.
 <br><br>
 Where errors exist, they are usually minor, such as the presence of invalid <code>alt</code> and <code>src</code> attributes in SVG image nodes (ignored by user agents). There are some instances of incorrectly-nested elements (e.g. "<a href="https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Flow_content">flow content</a>" wrapped in "<a href="https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Phrasing_content">phrasing content</a>").
-<br><br> 
-The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design. 
 <br><br>
-Pages rendered in the <strong>older</strong> design (currently journals, and ancillary pages such as search, indexes, and account management) have a slightly higher volume of parsing errors, which include more problematic errors such as <code>li</code> elements outside of <code>ul</code> elements and duplicate IDs, that may interfere with the ability of Assistive Technology to correctly identify some components. 
+The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design.
+<br><br>
+Pages rendered in the <strong>older</strong> design (currently journals, and ancillary pages such as search, indexes, and account management) have a slightly higher volume of parsing errors, which include more problematic errors such as <code>li</code> elements outside of <code>ul</code> elements and duplicate IDs, that may interfere with the ability of Assistive Technology to correctly identify some components.
 <br><br>
 Ancillary static pages (e.g. the pages linked to at the footer of each page, such as Terms and Conditions, Legal Information, and Accessibility, among others) are hand-built in HTML, without the use of a dynamic templating system. Hand-built content may contain unclosed or illegally nested elements. When we become aware of content with these problems, we immediately take steps to repair the HTML.
 <br><br>
-Pages located at order.springer.com contain parsing errors that may be problematic for Assistive Technology, including illegally-nested elements, invalid autocomplete values, and incomplete closing tags. 
+Pages located at order.springer.com contain parsing errors that may be problematic for Assistive Technology, including illegally-nested elements, invalid autocomplete values, and incomplete closing tags.
 <br><br>
 Third party advertising scripts may inject content that omits start and end tags, contains duplicate attributes or illegally nested elements. When we become aware of active advertisements with these problems, we immediately take steps to remove those advertisements from our pages.
 </td>
@@ -871,7 +871,7 @@ Third party advertising scripts may inject content that omits start and end tags
 <td>
 The pages found at link.springer.com generally use standard HTML and WAI-ARIA attributes to describe the identity, operation, and state of user interface elements to Assistive Technologies.
 <br><br>
-In some cases, WAI-ARIA attributes have been omitted where they would be helpful (e.g. no status update is triggered on the "date published" popup component on advanced search pages). In other cases WAI-ARIA roles or attributes may be misused in ways that cause elements to have misleading semantics. We are actively working to find and repair these problems. 
+In some cases, WAI-ARIA attributes have been omitted where they would be helpful (e.g. no status update is triggered on the "date published" popup component on advanced search pages). In other cases WAI-ARIA roles or attributes may be misused in ways that cause elements to have misleading semantics. We are actively working to find and repair these problems.
 <br><br>
 Other third party scripts, including the Freshdesk customer services widget, may present elements that lack adequate names and roles, making them difficult for screen reader users to access. When we become aware of deficiencies, we contact third party suppliers to request repairs.
 </td>
@@ -992,17 +992,17 @@ Other third party scripts, including the Freshdesk customer services widget, may
 </ul></td>
 <td>Partially Supports</td>
 <td>
-The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design. 
+The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design.
 <br><br>
-Pages rendered in the <strong>older</strong> design (currently journals, and ancillary pages such as search, indexes, and account management) use gradient background images that do not meet minimum contrast requirements between the text and one or more of the gradient background colours. 
+Pages rendered in the <strong>older</strong> design (currently journals, and ancillary pages such as search, indexes, and account management) use gradient background images that do not meet minimum contrast requirements between the text and one or more of the gradient background colours.
 <br><br>
 There are limited instances of promotional/call-to-action content (e.g. the "New books and journals are available every day" box on the homepage of link.springer.com) with poor contrast ratio.
 <br><br>
-Images of product covers (e.g. journals, books displayed on the homepage of link.springer.com) may contain text that does not meet WCAG AA contrast guidelines. On the homepage, these images are supplemented with visible text labels (but the text is triggered by mouse-dependent event handlers, and their visibility cannot be toggled by the keyboard). 
+Images of product covers (e.g. journals, books displayed on the homepage of link.springer.com) may contain text that does not meet WCAG AA contrast guidelines. On the homepage, these images are supplemented with visible text labels (but the text is triggered by mouse-dependent event handlers, and their visibility cannot be toggled by the keyboard).
 <br><br>
-Pages rendered in the <strong>newer</strong> design (currently articles, chapters, books, book series, reference works, reference work entries, and collections) meet WCAG AA contrast ratio requirements. 
+Pages rendered in the <strong>newer</strong> design (currently articles, chapters, books, book series, reference works, reference work entries, and collections) meet WCAG AA contrast ratio requirements.
 <br><br>
-Most text and images of text in the newer design have a contrast ratio of at least 4.5:1. Links generally fall slightly short of WCAG AA requirements, with a contrast ratio of 4.3:1. 
+Most text and images of text in the newer design have a contrast ratio of at least 4.5:1. Links generally fall slightly short of WCAG AA requirements, with a contrast ratio of 4.3:1.
 <br><br>
 Third party advertising scripts may inject content with insufficient contrast.
 </td>
@@ -1028,11 +1028,11 @@ Third party advertising scripts may inject content with insufficient contrast.
 </ul></td>
 <td>Partially Supports</td>
 <td>
-The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design. 
+The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design.
 <br><br>
-Pages rendered in the <strong>older</strong> design (currently journals, and ancillary pages such as search, indexes, and account management) can generally be resized without Assistive Technology up to 200 percent without loss of content or functionality. 
+Pages rendered in the <strong>older</strong> design (currently journals, and ancillary pages such as search, indexes, and account management) can generally be resized without Assistive Technology up to 200 percent without loss of content or functionality.
 <br><br>
-The flyout "search" and "menu" components in the header of the older design have fixed positions which may prevent users browsing with high magnification from being able to scroll through the page while the components are open. In the case of the "menu" component, only some of the menu can be used at high magnification, with the lower items cut off-screen. 
+The flyout "search" and "menu" components in the header of the older design have fixed positions which may prevent users browsing with high magnification from being able to scroll through the page while the components are open. In the case of the "menu" component, only some of the menu can be used at high magnification, with the lower items cut off-screen.
 <br><br>
 Pages rendered in the <strong>newer</strong> design (currently articles, chapters, books, book series, reference works, reference work entries, and collections) can be resized without Assistive Technology up to 400 percent without loss of content or functionality.  
 <br><br>
@@ -1060,9 +1060,9 @@ Third party advertising scripts may inject non-responsive content that loses or 
 </ul></td>
 <td>Partially Supports</td>
 <td>
-Content in journals, books, series, protocols, reference works or proceedings may include complex images that contain images of text. In most cases these images are used to supplement the text content they appear alongside. In some cases (e.g. charts, graphs, or maps, among others), the text content presented alongside may be insufficient to explain the contents of the image. 
+Content in journals, books, series, protocols, reference works or proceedings may include complex images that contain images of text. In most cases these images are used to supplement the text content they appear alongside. In some cases (e.g. charts, graphs, or maps, among others), the text content presented alongside may be insufficient to explain the contents of the image.
 <br><br>
-Images of product covers (e.g. journals or books displayed on the homepage of link.springer.com) may contain text. On the homepage, these images are supplemented with visible text labels, but the text is triggered by mouse-dependent event handlers, and their visibility cannot be toggled by the keyboard alone. 
+Images of product covers (e.g. journals or books displayed on the homepage of link.springer.com) may contain text. On the homepage, these images are supplemented with visible text labels, but the text is triggered by mouse-dependent event handlers, and their visibility cannot be toggled by the keyboard alone.
 <br><br>
 Third party advertising scripts may inject images containing images of text.
 </td>
@@ -1085,7 +1085,7 @@ Third party advertising scripts may inject images containing images of text.
 <td>Partially Supports</td>
 <td>Most parts of this product are responsive. Content can be presented without loss of information or functionality, and without requiring scrolling in two dimensions per the specifications in this criterion.
 
-Third party advertising scripts may inject non-responsive content that loses or obscures information when text is resized or the screen is magnified. 
+Third party advertising scripts may inject non-responsive content that loses or obscures information when text is resized or the screen is magnified.
 </td>
 </tr>
 <tr id="non-text-contrast" valign="top">
@@ -1105,9 +1105,9 @@ Third party advertising scripts may inject non-responsive content that loses or 
 </td>
 <td>Partially Supports</td>
 <td>
-The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design. 
+The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design.
 <br><br>
-Pages rendered in the <strong>older</strong> design (currently journals, and ancillary pages such as search, indexes, and account management) contain user interface icons that do not meet minimum contrast requirements for non-text content. 
+Pages rendered in the <strong>older</strong> design (currently journals, and ancillary pages such as search, indexes, and account management) contain user interface icons that do not meet minimum contrast requirements for non-text content.
 <br><br>
 Some complex non-text images in journals, books, series, protocols, reference works and proceedings may have insufficient contrast. Examples may include images of charts, graphs, diagrams, or maps. Generally, these images are used to supplement text content.
 </td>
@@ -1129,9 +1129,9 @@ Some complex non-text images in journals, books, series, protocols, reference wo
 </td>
 <td>Partially Supports</td>
 <td>
-No loss of content or functionality occurs by setting the text spacing properties specified by this criterion anywhere in this product, except for the search results page and [homepage](https://link.springer.com) where a collision may occur between some of the filters. 
+No loss of content or functionality occurs by setting the text spacing properties specified by this criterion anywhere in this product, except for the search results page and [homepage](https://link.springer.com) where a collision may occur between some of the filters.
 <br><br>
-The search results page is rendered in an older design - we are in the process of transferring this content from the older design to the newer design which will pass this criterion. 
+The search results page is rendered in an older design - we are in the process of transferring this content from the older design to the newer design which will pass this criterion.
 </td>
 </tr>
 <tr id="content-on-hover-or-focus" valign="top">
@@ -1153,7 +1153,7 @@ The search results page is rendered in an older design - we are in the process o
 <td>
 The search results page contains three tooltip components that toggle visibility on both hover and focus events. The tooltip components do not meet the Dismissable, Hoverable, or Persistent requirements specified by this criterion.
 <br><br>
-No other examples of components that trigger visibility of additional information on hover or focus exist in the pages of this product. 
+No other examples of components that trigger visibility of additional information on hover or focus exist in the pages of this product.
 </td>
 </tr>
 <tr id="multiple-ways" valign="top">
@@ -1179,7 +1179,7 @@ No other examples of components that trigger visibility of additional informatio
 <td>
 Users may use the search function or the provided category browsing links to access any part of this product. The main navigation component can also be used to access the main content index pages.
 <br><br>
-The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design. 
+The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design.
 <br><br>
 The flyout "menu" component in the header of the older design has a fixed position which may prevent users who browse with high magnification from being able to access all items in the menu.  
 </td>
@@ -1205,11 +1205,11 @@ The flyout "menu" component in the header of the older design has a fixed positi
 </ul></td>
 <td>Partially Supports</td>
 <td>
-The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design. 
+The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design.
 <br><br>
-Pages rendered in the <strong>older</strong> design (currently journals, and ancillary pages such as search, indexes, and account management) may incorrectly use label elements for other purposes (e.g. for error messages on account management pages), omit labels for some functionality (e.g. the pagination number field on advanced search results pages and the text input for the main search component in the page banner). 
+Pages rendered in the <strong>older</strong> design (currently journals, and ancillary pages such as search, indexes, and account management) may incorrectly use label elements for other purposes (e.g. for error messages on account management pages), omit labels for some functionality (e.g. the pagination number field on advanced search results pages and the text input for the main search component in the page banner).
 <br><br>
-Level one headings are omitted on some pages (e.g. search results pages). Other pages have multiple level one headings (e.g. static ancillary pages such as link.springer.com/termsandconditions). Some informational pages (e.g. Journal updates) do not use correctly-structured heading levels. 
+Level one headings are omitted on some pages (e.g. search results pages). Other pages have multiple level one headings (e.g. static ancillary pages such as link.springer.com/termsandconditions). Some informational pages (e.g. Journal updates) do not use correctly-structured heading levels.
 <br><br>
 We are actively working to find and repair these problems.  
 <br><br>
@@ -1239,13 +1239,13 @@ The Freshdesk customer services widget injects controls with inadequate labels, 
 </ul></td>
 <td>Partially Supports</td>
 <td>
-The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design. 
+The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design.
 <br><br>
-Pages rendered in the <strong>older</strong> design (currently journals, and ancillary pages such as search, indexes, and account management) use default browser focus rings only for interactive components. 
+Pages rendered in the <strong>older</strong> design (currently journals, and ancillary pages such as search, indexes, and account management) use default browser focus rings only for interactive components.
 <br><br>
 Pages rendered in the <strong>newer</strong> design (currently articles, chapters, books, book series, reference works, reference work entries, and collections) use highly-visible focus styles, including yellow focus rings or yellow backgrounds.
 <br><br>
-Pages found at order.springer.com use default browser focus rings only for interactive components. 
+Pages found at order.springer.com use default browser focus rings only for interactive components.
 <br><br>
 Third party scripts, including advertising, may inject components that remove focus styles.
 </td>
@@ -1271,9 +1271,9 @@ Third party scripts, including advertising, may inject components that remove fo
 </ul></td>
 <td>Partially Supports</td>
 <td>
-Content in journals, books, series, protocols, reference works or proceedings may include or be completely composed of text in languages other than that defined in the HTML <code>lang</code> attribute. Research content supports the inclusion of correct `lang` attributes for mixed-language content in some areas such as article titles and summary sections, but not all parts of mixed-language pages are covered. We currently have no method of confirming the inclusion of appropriate <code>lang</code> attributes for pieces of text that may use a different language to the main document. 
+Content in journals, books, series, protocols, reference works or proceedings may include or be completely composed of text in languages other than that defined in the HTML <code>lang</code> attribute. Research content supports the inclusion of correct `lang` attributes for mixed-language content in some areas such as article titles and summary sections, but not all parts of mixed-language pages are covered. We currently have no method of confirming the inclusion of appropriate <code>lang</code> attributes for pieces of text that may use a different language to the main document.
 <br><br>
-Titles in the cart at order.springer.com may be published in multiple languages. The correct <code>lang</code> attribute for titles in a language different to that of the overall document is omitted. 
+Titles in the cart at order.springer.com may be published in multiple languages. The correct <code>lang</code> attribute for titles in a language different to that of the overall document is omitted.
 <br><br>
 Third party scripts may inject components that use a different language to the page content - for example a targeted advertisement may use the native language of the user, and not be marked up with a separate <code>lang</code> attribute.
 </td>
@@ -1299,15 +1299,15 @@ Third party scripts may inject components that use a different language to the p
 </ul></td>
 <td>Partially Supports</td>
 <td>
-The SpringerLink website contains content that is rendered in two separate, inconsistent designs. The designs have different navigation methods, within the same collections of pages. We are in the process of transferring all content from the older design to the newer design. 
+The SpringerLink website contains content that is rendered in two separate, inconsistent designs. The designs have different navigation methods, within the same collections of pages. We are in the process of transferring all content from the older design to the newer design.
 <br><br>
-Pages rendered in the <strong>older</strong> design are currently journals, and ancillary pages such as search, indexes, and account management. 
+Pages rendered in the <strong>older</strong> design are currently journals, and ancillary pages such as search, indexes, and account management.
 <br><br>
-Pages rendered in the <strong>newer</strong> design are currently articles, chapters, books, book series, reference works, reference work entries, and collections. 
+Pages rendered in the <strong>newer</strong> design are currently articles, chapters, books, book series, reference works, reference work entries, and collections.
 <br><br>
-When the transfer process is complete, the navigation methods between designs will be broadly consistent. 
+When the transfer process is complete, the navigation methods between designs will be broadly consistent.
 <br><br>
- The checkout configurations deal with sensitive information and have intentionally been made more simple in design. They do not share the same navigation system as the main site, but the navigation of these sets of pages is internally consistent. 
+ The checkout configurations deal with sensitive information and have intentionally been made more simple in design. They do not share the same navigation system as the main site, but the navigation of these sets of pages is internally consistent.
 </td>
 </tr>
 <tr id="consistent-identification" valign="top">
@@ -1331,15 +1331,15 @@ When the transfer process is complete, the navigation methods between designs wi
 </ul></td>
 <td>Partially Supports</td>
 <td>
-The SpringerLink website contains content that is rendered in two separate, inconsistent designs. We are in the process of transferring all content from the older design to the newer design. 
+The SpringerLink website contains content that is rendered in two separate, inconsistent designs. We are in the process of transferring all content from the older design to the newer design.
 <br><br>
-Pages rendered in the <strong>older</strong> design are currently journals, and ancillary pages such as search, indexes, and account management. 
+Pages rendered in the <strong>older</strong> design are currently journals, and ancillary pages such as search, indexes, and account management.
 <br><br>
-Pages rendered in the <strong>newer</strong> design are currently articles, chapters, books, book series, reference works, reference work entries, and collections. 
+Pages rendered in the <strong>newer</strong> design are currently articles, chapters, books, book series, reference works, reference work entries, and collections.
 <br><br>
 When the transfer process is complete, content will use a unified design style with consistent presentation and functionality.
 <br><br>
-The checkout configurations deal with sensitive information and have intentionally been made more simple in design. They do not share the same navigation system as the main site, but the presentation of these sets of pages is internally consistent, and the tasks performed are unlike those performed elsewhere on the site. 
+The checkout configurations deal with sensitive information and have intentionally been made more simple in design. They do not share the same navigation system as the main site, but the presentation of these sets of pages is internally consistent, and the tasks performed are unlike those performed elsewhere on the site.
 </td>
 </tr>
 <tr id="error-suggestion" valign="top">
@@ -1363,13 +1363,13 @@ The checkout configurations deal with sensitive information and have intentional
 </ul></td>
 <td>Partially Supports</td>
 <td>
-Where user input errors are automatically detected by our own software, those errors are identified to the user with warning text adjacent to the input field. Unless it would present a risk to security, the warning text describes the error and what the user should do to correct it. 
+Where user input errors are automatically detected by our own software, those errors are identified to the user with warning text adjacent to the input field. Unless it would present a risk to security, the warning text describes the error and what the user should do to correct it.
 <br><br>
-The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design. 
+The SpringerLink website contains content that is rendered in two separate designs. We are in the process of transferring all content from the older design to the newer design.
 <br><br>
 Pages rendered in the <strong>older</strong> design (currently journals, and ancillary pages such as search, indexes, and account management) use unsemantic, unassociated label elements to mark up errors.
 <br><br>
-Pages located at order.springer.com rely solely on built-in browser error checking, and do not identify errors in text. Some users with and without Assistive Technology may be unable to access these error states. 
+Pages located at order.springer.com rely solely on built-in browser error checking, and do not identify errors in text. Some users with and without Assistive Technology may be unable to access these error states.
 </td>
 </tr>
 <tr id="error-prevention-legal-financial-data" valign="top">
@@ -1411,7 +1411,7 @@ Pages located at order.springer.com rely solely on built-in browser error checki
 </td>
 <td>Partially Supports</td>
 <td>Status messages that do not receive focus are presented in text. Some are marked up with programmatic roles (e.g. `role="alert"` on some error messages), but there is no consistent, single approach to status messages across the multiple designs.   ARIA Live Regions are not generally used.</td>
- 
+
 </tr>
 </tbody>
 </table>
@@ -1424,7 +1424,7 @@ Notes: This product has not been evaluated for WCAG 2.1 Level AAA conformance.
 
 ### Chapter 3: [Functional Performance Criteria](https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh/draft-rule-2011/chapter-3-functional-performance-criteria) (FPC)
 
-Notes: See [WCAG section](#wcag-20-report) for full details. 
+Notes: See [WCAG section](#wcag-20-report) for full details.
 
 <table>
 <thead>
@@ -1489,7 +1489,7 @@ Notes: This product is a web software application and is not subject to the requ
 
 ### Chapter 5: [Software](https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh/draft-rule-2011/chapter-5-platforms-and-applications)
 
-Notes: See [WCAG section](#wcag-20-report) for full details. 
+Notes: See [WCAG section](#wcag-20-report) for full details.
 
 <table>
 <thead>
@@ -1586,7 +1586,7 @@ See WCAG sections <a href="#info-and-relationships">1.3.1 Info and Relationships
 <td headers="502-services chap-5-remarks">
 The pages of this product use standard plain text in HTML.
 <br><br>
-Content in journals, books, series, protocols, reference works or proceedings may contain images of text without adequate programmatically determinable alternatives. 
+Content in journals, books, series, protocols, reference works or proceedings may contain images of text without adequate programmatically determinable alternatives.
 </td>
 </tr>
 <tr>
@@ -1603,9 +1603,9 @@ Content in journals, books, series, protocols, reference works or proceedings ma
 <td headers="502-services chap-5-criteria">502.3.11 Actions on Objects</td>
 <td headers="502-services chap-5-conformance">Partially Supports</td>
 <td headers="502-services chap-5-remarks">
-The pages of this product use standard HTML or WAI-ARIA object attributes for maximum compatibility with Assistive Technologies. Some content, including that injected by third party scripts, cannot be interacted with easily or at all by keyboard or by other Assistive Technologies. 
+The pages of this product use standard HTML or WAI-ARIA object attributes for maximum compatibility with Assistive Technologies. Some content, including that injected by third party scripts, cannot be interacted with easily or at all by keyboard or by other Assistive Technologies.
 <br><br>
-See WCAG sections <a href="#info-and-relationships">1.3.1 Info and Relationships</a>, and <a href="#keyboard">2.1.1 Keyboard</a> for further detail. 
+See WCAG sections <a href="#info-and-relationships">1.3.1 Info and Relationships</a>, and <a href="#keyboard">2.1.1 Keyboard</a> for further detail.
 </td>
 </tr>
 <tr>
@@ -1628,7 +1628,7 @@ See WCAG sections <a href="#use-of-color">1.4.1 Use of Color</a> and <a href="#f
 <td headers="502-services chap-5-remarks">
 The pages of this product use standard HTML and WAI-ARIA attributes to describe the identity, operation, and state of user interface elements to Assistive Technologies.
 <br><br>
-Some components omit or misuse WAI-ARIA attributes in a way that prevents users of some Assistive Technologies from being able to perceive changes in state. We are actively working to find and repair these problems. 
+Some components omit or misuse WAI-ARIA attributes in a way that prevents users of some Assistive Technologies from being able to perceive changes in state. We are actively working to find and repair these problems.
 <br><br>
 Some third party scripts may inject content that fails to notify users of changes in state.
 <br><br>
@@ -1776,13 +1776,13 @@ Notes: This report covers accessibility conformance for the web product and does
 
 Notes: This product supports standard web Assistive Technologies and is therefore not subject to the Closed Functionality criteria described in this chapter.
 
-### Chapter [6: ICT with Two-Way Voice Communication](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=30) 
+### Chapter [6: ICT with Two-Way Voice Communication](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=30)
 
 Notes: This product does not offer two-way voice communication and is therefore not subject to the requirements of this chapter.
 
-### Chapter [7: ICT with Video Capabilities](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=35) 
+### Chapter [7: ICT with Video Capabilities](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=35)
 
-Notes: See [WCAG section](#wcag-20-report) for full details. 
+Notes: See [WCAG section](#wcag-20-report) for full details.
 
 <table>
 <thead>
@@ -1859,7 +1859,7 @@ Notes: This product does not include non-web documents and is therefore not subj
 </thead>
 <tbody>
  <tr>
- <th scope="column" colspan="3" id="11-gen">11.0 General (informative)</th> 
+ <th scope="column" colspan="3" id="11-gen">11.0 General (informative)</th>
  </tr>
 <tr>
 <td headers="11-gen chap-11-criteria">11.1.1 through 11.4.1.3</td>


### PR DESCRIPTION
In this PR I am preparing the base template for future VPATs, and also updating the Link and Nature versions so they use the same info as the base template. 

Changes comprise:

* Some more concrete detail on evaluation methods 
* A bunch of WCAG 2.0s amended to WCAG 2.xs, because the stuff they refer to is valid for both 2.0 and 2.1 (and will one day be valid for 2.2 also)
* Some whitespace removal because my editor does that for free 😅 