### PR TITLE
Remove obsolete redirects

### DIFF
--- a/nature-aip.md
+++ b/nature-aip.md
@@ -1,5 +1,0 @@
-# <a name="document-top"></a> nature.com (AIP)<br>Voluntary Product Accessibility Template&reg; (VPAT&trade;)
-
-The data below is valid on the date provided: 21st January 2019.
-
-Please refer to the [Nature VPAT](https://github.com/springernature/vpat/blob/master/nature.md) for current conformance levels.

--- a/nature-content-discovery.md
+++ b/nature-content-discovery.md
@@ -1,5 +1,0 @@
-# nature.com (content discovery pages) Accessibility Conformance Report
-
-The data below is valid on the date provided: 12th September 2019.
-
-Please refer to the [Nature VPAT](https://github.com/springernature/vpat/blob/master/nature.md) for current conformance levels.  

--- a/nature-legacy.md
+++ b/nature-legacy.md
@@ -1,5 +1,0 @@
-# <a name="document-top"></a> nature.com (Legacy)<br>Voluntary Product Accessibility Template&reg; (VPAT&trade;)
-
-The data below is valid on the date provided: 21st January 2019.
-
-Please refer to the [Nature VPAT](https://github.com/springernature/vpat/blob/master/nature.md) for current conformance levels.

--- a/nature-magazine.md
+++ b/nature-magazine.md
@@ -1,5 +1,0 @@
-# <a name="document-top"></a>Nature Magazine Voluntary Product Accessibility Template (VPAT)
-
-The data below is valid on the date provided: 21st January 2019.
-
-Please refer to the [Nature VPAT](https://github.com/springernature/vpat/blob/master/nature.md) for current conformance levels.

--- a/nature-oscar.md
+++ b/nature-oscar.md
@@ -1,5 +1,0 @@
-# <a name="document-top"></a> nature.com (mosaic - journals)<br>Voluntary Product Accessibility Template&reg; (VPAT&trade;)
-
-The data below is valid on the date provided: 21st January 2019.
-
-Please refer to the [Nature VPAT](https://github.com/springernature/vpat/blob/master/nature.md) for current conformance levels.


### PR DESCRIPTION
We haven't maintained these files for 5 years because we're now working with a much less fragmented product landscape. Keeping them hanging around makes it look as though we have abandoned VPATs (because they look like VPATs from the index, when in reality they're just manual redirections to the real VPATs).

I've checked with Institutional Sales and we're broadly agreed that removing these files is unlikely to affect any customers, so, out they go 😄 