### PR TITLE
reorder VPAT version history

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,62 +4,6 @@ This repository contains Voluntary Product Accessibility Template&reg; (VPAT&reg
 
 The VPAT is a template used to document a product's conformance with accessibility standards and guidelines. The purpose of the VPAT is to assist customers and buyers in making preliminary assessments regarding the availability of commercial "Electronic and Information Technology", also referred to as "Information and Communication Technology" (ICT) products and services with features that support accessibility.
 
-> Documents in this repository will conform to VPAT&reg; `Version 1.0`, `Version 2.2`, `Version 2.3`, `Version 2.4` or the newer `Version 2.4 Rev`. **New documents in this repository should conform to the latest standard (2.4 Rev) using the [template provided](https://github.com/springernature/vpat/blob/master/base-template.md)** 
-
-### VPAT&reg; Version 1.0
-
-Voluntary Product Accessibility Template&reg; (VPAT&reg;) documents for Springer Nature products, outlining Section 508 accessibility information for Springer Nature products.
-
-The first table of the Template provides a summary view of the Section 508 Standards. The subsequent tables provide more detailed views of each subsection.
-
-There are three columns in each table. The first column of the Summary Table describes the subsections of subparts B and C of the Standards. The second describes the supporting features of the product or refers you to the corresponding detailed table, e.g. “equivalent facilitation”. The third contains any additional remarks and explanations regarding the product.
-
-In the subsequent tables, the first column contains the lettered paragraphs of the subsections. The second column describes the supporting features of the product with regard to that paragraph. The third column contains any additional remarks and explanations regarding the product.
-
-### VPAT&reg; Version 2.2 (July 2018)
-
-VPAT version 2.2 has been updated to cover changes to Section 508 that were finalized and published in 2017, commonly known as the "Section 508 Refresh", which incorporates the [Web Content Accessibility Guidelines 2.0](https://www.w3.org/TR/WCAG20/) (WCAG 2.0 or ISO/IEC 40500) by reference. VPAT 2.0 also can be used to report against WCAG 2.0 and the European standard EN 301 549.
-
-It includes the following standards/guidelines:
-
-* [Web Content Accessibility Guidelines 2.0](http://www.w3.org/TR/2008/REC-WCAG20-20081211/)
-* [Revised Section 508 standards](https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh/final-rule/text-of-the-standards-and-guidelines) as published by the U.S. Access Board in the Federal Register on January 18, 2017, including the [Corrections to the ICT Final Rule](https://web.archive.org/web/20190712025000/https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh/corrections-to-the-ict-final-rule) as published by the US Access Board in the Federal Register on January 22, 2018
-* [EN 301 549  Accessibility requirements suitable for public procurement of ICT products and services in Europe, - V1.1.2 (2015-04)](https://web.archive.org/web/20210308133338/https://mandate376.standards.eu/)
-
-### VPAT&reg; Version 2.3 (April 2019)
-
-VPAT version 2.3 has been updated to cover changes to the European standard EN 301 549 that were finalised and published in 2018, which incorporates the [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/) (WCAG 2.1) by reference.
-
-It includes the following standards/guidelines:
-
-* [Web Content Accessibility Guidelines 2.0](http://www.w3.org/TR/2008/REC-WCAG20-20081211/)
-* [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21)
-* [Revised Section 508 standards](https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh/final-rule/text-of-the-standards-and-guidelines) published January 18, 2017 and corrected January 22, 2018
-* [EN 301 549  Accessibility requirements suitable for public procurement of ICT products and services in Europe, - V2.1.2 (2018-08)](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/02.01.02_60/en_301549v020102p.pdf)
-
-### VPAT&reg; Version 2.4 (February 2020)
-
-VPAT version 2.4 has been updated to cover changes to the European standard EN 301 549 that were finalised and published in 2019.
-
-It includes the following standards/guidelines:
-
-* [Web Content Accessibility Guidelines 2.0](http://www.w3.org/TR/2008/REC-WCAG20-20081211/)
-* [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21)
-* [Revised Section 508 standards](https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh/final-rule/text-of-the-standards-and-guidelines) published January 18, 2017 and corrected January 22, 2018
-* [EN 301 549  Accessibility requirements suitable for public procurement of ICT products and services in Europe, - V3.1.1 (2019-11)](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.01.01_60/en_301549v030101p.pdf)
-  
-### VPAT&reg; Version 2.4 Rev (March 2022)
-
-VPAT verson 2.4 Rev has been updated to cover changes to the European standard EN 301 549 that were finalised and published in 2021. 
-
-It includes the following standards/guidelines:
-
-* [Web Content Accessibility Guidelines 2.0](https://www.w3.org/TR/2008/REC-WCAG20-20081211/) 
-* [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
-* [Revised Section 508 standards published January 18, 2017 and corrected January 22, 2018](https://www.access-board.gov/ict/) 
-* [EN 301 549 Accessibility requirements for ICT products and services - V3.1.1 (2019-11)](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.01.01_60/en_301549v030101p.pdf) 
-* [EN 301 549 Accessibility requirements for ICT products and services - V3.2.1 (2021-03)](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf)
-
 ## Creating a new VPAT
 
 To create a new VPAT for a product, use a *copy* of the [base template](./base-template.md) as a starting point. Ensure that you update the following placeholders within your copied template:
@@ -77,3 +21,69 @@ then add your product to the list below.
 - [SpringerOpen](./springeropen.md)
 - [SpringerLink](./springerlink.md)
 - [Nature](./nature.md)
+
+## VPAT version history
+
+> Documents in this repository will conform to VPAT&reg; `Version 1.0`, `Version 2.2`, `Version 2.3`, `Version 2.4` or the newer `Version 2.4 Rev`.  
+>
+>**New documents in this repository should conform to the latest standard (2.4 Rev) using the [template provided](https://github.com/springernature/vpat/blob/master/base-template.md)**
+
+### VPAT&reg; Version 2.4 Rev (March 2022)
+
+VPAT verson 2.4 Rev has been updated to cover changes to the European standard EN 301 549 that were finalised and published in 2021.
+
+It includes the following standards/guidelines:
+
+* [Web Content Accessibility Guidelines 2.0](https://www.w3.org/TR/2008/REC-WCAG20-20081211/)
+* [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/)
+* [Revised Section 508 standards published January 18, 2017 and corrected January 22, 2018](https://www.access-board.gov/ict/)
+* [EN 301 549 Accessibility requirements for ICT products and services - V3.1.1 (2019-11)](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.01.01_60/en_301549v030101p.pdf)
+* [EN 301 549 Accessibility requirements for ICT products and services - V3.2.1 (2021-03)](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf)
+
+***
+
+<p align="center"><strong>DO NOT USE ANY OF THE VERSIONS BELOW FOR NEW DOCUMENTS.</strong></p>
+
+***
+
+### VPAT&reg; Version 2.4 (February 2020)
+
+VPAT version 2.4 has been updated to cover changes to the European standard EN 301 549 that were finalised and published in 2019.
+
+It includes the following standards/guidelines:
+
+* [Web Content Accessibility Guidelines 2.0](http://www.w3.org/TR/2008/REC-WCAG20-20081211/)
+* [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21)
+* [Revised Section 508 standards](https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh/final-rule/text-of-the-standards-and-guidelines) published January 18, 2017 and corrected January 22, 2018
+* [EN 301 549  Accessibility requirements suitable for public procurement of ICT products and services in Europe, - V3.1.1 (2019-11)](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.01.01_60/en_301549v030101p.pdf)
+
+### VPAT&reg; Version 2.3 (April 2019)
+
+VPAT version 2.3 has been updated to cover changes to the European standard EN 301 549 that were finalised and published in 2018, which incorporates the [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21/) (WCAG 2.1) by reference.
+
+It includes the following standards/guidelines:
+
+* [Web Content Accessibility Guidelines 2.0](http://www.w3.org/TR/2008/REC-WCAG20-20081211/)
+* [Web Content Accessibility Guidelines 2.1](https://www.w3.org/TR/WCAG21)
+* [Revised Section 508 standards](https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh/final-rule/text-of-the-standards-and-guidelines) published January 18, 2017 and corrected January 22, 2018
+* [EN 301 549  Accessibility requirements suitable for public procurement of ICT products and services in Europe, - V2.1.2 (2018-08)](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/02.01.02_60/en_301549v020102p.pdf)
+
+### VPAT&reg; Version 2.2 (July 2018)
+
+VPAT version 2.2 has been updated to cover changes to Section 508 that were finalized and published in 2017, commonly known as the "Section 508 Refresh", which incorporates the [Web Content Accessibility Guidelines 2.0](https://www.w3.org/TR/WCAG20/) (WCAG 2.0 or ISO/IEC 40500) by reference. VPAT 2.0 also can be used to report against WCAG 2.0 and the European standard EN 301 549.
+
+It includes the following standards/guidelines:
+
+* [Web Content Accessibility Guidelines 2.0](http://www.w3.org/TR/2008/REC-WCAG20-20081211/)
+* [Revised Section 508 standards](https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh/final-rule/text-of-the-standards-and-guidelines) as published by the U.S. Access Board in the Federal Register on January 18, 2017, including the [Corrections to the ICT Final Rule](https://web.archive.org/web/20190712025000/https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-ict-refresh/corrections-to-the-ict-final-rule) as published by the US Access Board in the Federal Register on January 22, 2018
+* [EN 301 549  Accessibility requirements suitable for public procurement of ICT products and services in Europe, - V1.1.2 (2015-04)](https://web.archive.org/web/20210308133338/https://mandate376.standards.eu/)
+
+### VPAT&reg; Version 1.0
+
+Voluntary Product Accessibility Template&reg; (VPAT&reg;) documents for Springer Nature products, outlining Section 508 accessibility information for Springer Nature products.
+
+The first table of the Template provides a summary view of the Section 508 Standards. The subsequent tables provide more detailed views of each subsection.
+
+There are three columns in each table. The first column of the Summary Table describes the subsections of subparts B and C of the Standards. The second describes the supporting features of the product or refers you to the corresponding detailed table, e.g. “equivalent facilitation”. The third contains any additional remarks and explanations regarding the product.
+
+In the subsequent tables, the first column contains the lettered paragraphs of the subsections. The second column describes the supporting features of the product with regard to that paragraph. The third column contains any additional remarks and explanations regarding the product.


### PR DESCRIPTION
In this PR I have:

1. Moved the instructions on how to create a new VPAT to the top of the page instead of the bottom
2. Reordered the VPAT version history so that v1 is at the bottom and v2.4 is at the top 
3. Added an extra warning to NOT use any VPAT version below the current one