### PR TITLE
Nature 2.5rev update

### DIFF
--- a/nature.md
+++ b/nature.md
@@ -61,7 +61,7 @@ Tables 1 and 2 also document conformance with:
   - Chapter 5 – 501.1 Scope, 504.2 Content Creation or Editing
   - Chapter 6 – 602.3 Electronic Support Documentation
 
-**Note**: When reporting on conformance with the WCAG 2.x Success Criteria, they are scoped for full pages, complete processes, and accessibility-supported ways of using technology as documented in the [WCAG 2.1 Conformance Requirements](https://www.w3.org/TR/WCAG21/#conformance-reqs).
+**Note**: When reporting on conformance with the WCAG 2.1 Success Criteria, they are scoped for full pages, complete processes, and accessibility-supported ways of using technology as documented in the [WCAG 2.1 Conformance Requirements](https://www.w3.org/TR/WCAG21/#conformance-reqs).
 
 ### Table 1: Success Criteria, Level A
 

--- a/nature.md
+++ b/nature.md
@@ -52,8 +52,14 @@ The terms used in the Conformance Level information are defined as follows:
 ## WCAG 2.1 Report
 
 Tables 1 and 2 also document conformance with:
-- EN 301 549:  Clause 9 - Web, Clauses 10.1-10.4 of Clause 10 - Non-Web documents, and Clauses 11.1-11.4 and 11.8.2 of Clause 11 - Software, and Clauses 12.1.2 and 12.2.4 of Clause 12 – Documentation and support services
-- Revised Section 508: Chapter 5 – 501.1 Scope, 504.2 Content Creation or Editing, and Chapter 6 – 602.3 Electronic Support Documentation.
+- EN 301 549:
+  - Clause 9 - Web
+  - Clauses 10.1-10.4 of Clause 10 - Non-Web documents
+  - Clauses 11.1-11.4 and 11.8.2 of Clause 11 - Software
+  - Clauses 12.1.2 and 12.2.4 of Clause 12 – Documentation and support services
+- Revised Section 508:
+  - Chapter 5 – 501.1 Scope, 504.2 Content Creation or Editing
+  - Chapter 6 – 602.3 Electronic Support Documentation
 
 **Note**: When reporting on conformance with the WCAG 2.x Success Criteria, they are scoped for full pages, complete processes, and accessibility-supported ways of using technology as documented in the [WCAG 2.1 Conformance Requirements](https://www.w3.org/TR/WCAG21/#conformance-reqs).
 

--- a/nature.md
+++ b/nature.md
@@ -1615,7 +1615,7 @@ Notes: This report covers accessibility conformance for the web product and does
 
 ## EN 301 549 Report
 
-### Chapter 4: [4.2 Functional Performance Statements](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=20) (FPS)
+### Clause 4: [4.2 Functional Performance Statements](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=20) (FPS)
 
 <table>
 <thead>
@@ -1684,15 +1684,15 @@ Notes: This report covers accessibility conformance for the web product and does
 </tbody>
 </table>
 
-### Chapter [5: Generic Requirements](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=23)
+### Clause [5: Generic Requirements](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=23)
 
 Notes: This product supports standard web Assistive Technologies and is therefore not subject to the Closed Functionality criteria described in this chapter.
 
-### Chapter [6: ICT with Two-Way Voice Communication](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=30)
+### Clause [6: ICT with Two-Way Voice Communication](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=30)
 
 Notes: This product does not offer two-way voice communication and is therefore not subject to the requirements of this chapter.
 
-### Chapter [7: ICT with Video Capabilities](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=35)
+### Clause [7: ICT with Video Capabilities](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=35)
 
 Notes:
 
@@ -1746,19 +1746,19 @@ Notes:
 </tbody>
 </table>
 
-### Chapter [8: Hardware](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=37)
+### Clause [8: Hardware](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=37)
 
 Notes: This product is a web software application and is not subject to the requirements of this chapter.
 
-### Chapter [9: Web](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=45)
+### Clause [9: Web](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=45)
 
 Notes: Please see [WCAG 2.1 section](#wcag-21-report).
 
-### Chapter [10: Non-Web Documents](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=52)
+### Clause [10: Non-Web Documents](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=52)
 
 Notes: This product does not include non-web documents and is therefore not subject to the requirements of this chapter.
 
-### Chapter [11: Software](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=52)
+### Clause [11: Software](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=52)
 
 <table>
 <thead>
@@ -1917,11 +1917,11 @@ Notes: This product does not include non-web documents and is therefore not subj
 </tbody>
 </table>
 
-### Chapter [12: Documentation and Support Services](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=84)
+### Clause [12: Documentation and Support Services](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=84)
 
 Notes: This report covers accessibility conformance for the web product and does not provide Documentation or Support Services.
 
-### Chapter [13: ICT Providing Relay or Emergency Service Access](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=86)
+### Clause [13: ICT Providing Relay or Emergency Service Access](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf#page=86)
 
 Notes: This product does not provide any relay services, or access for Emergency Services.
 

--- a/nature.md
+++ b/nature.md
@@ -52,7 +52,7 @@ The terms used in the Conformance Level information are defined as follows:
 ## WCAG 2.1 Report
 
 Tables 1 and 2 also document conformance with:
-- EN 301 549:  Chapter 9 - Web, Sections 10.1-10.4 of Chapter 10 - Non-Web documents, and Sections 11.1-11.4 and 11.8.2 of Chapter 11 - Non-Web Software (open and closed functionality), and Sections 12.1.2 and 12.2.4 of Chapter 12 – Documentation
+- EN 301 549:  Clause 9 - Web, Clauses 10.1-10.4 of Clause 10 - Non-Web documents, and Clauses 11.1-11.4 and 11.8.2 of Clause 11 - Software, and Clauses 12.1.2 and 12.2.4 of Clause 12 – Documentation and support services
 - Revised Section 508: Chapter 5 – 501.1 Scope, 504.2 Content Creation or Editing, and Chapter 6 – 602.3 Electronic Support Documentation.
 
 **Note**: When reporting on conformance with the WCAG 2.x Success Criteria, they are scoped for full pages, complete processes, and accessibility-supported ways of using technology as documented in the [WCAG 2.1 Conformance Requirements](https://www.w3.org/TR/WCAG21/#conformance-reqs).

--- a/nature.md
+++ b/nature.md
@@ -1,5 +1,5 @@
 # Nature Accessibility Conformance Report International Edition
-(Based on VPAT® Version 2.4Rev)
+(Based on VPAT® Version 2.5Rev)
 
 **Report Date**: 18th August 2023  
 **Name of Product/Version**: Nature.com _(we do not version our software)_  

--- a/nature.md
+++ b/nature.md
@@ -47,7 +47,7 @@ The terms used in the Conformance Level information are defined as follows:
 - **Partially Supports**: Some functionality of the product does not meet the criterion.
 - **Does Not Support**: The majority of product functionality does not meet the criterion.
 - **Not Applicable**: The criterion is not relevant to the product.
-- **Not Evaluated**: The product has not been evaluated against the criterion. This can be used only in WCAG 2.x Level AAA.
+- **Not Evaluated**: The product has not been evaluated against the criterion. This can be used only in WCAG Level AAA.
 
 ## WCAG 2.1 Report
 


### PR DESCRIPTION
This PR updates the Nature VPAT to use the INT template version 2.5rev.

The changes suggested comprise of administrative amends only in language and structure. Commits include changes introduced by both template versions 2.5 and 2.5rev, as the current Nature VPAT is two versions behind.

There are no changes to the conformance stated or WCAG standard used - this will be done as a separate task.

### 2.5rev changes

- Update template version number stated
- Replace “Chapter” with “Clause” when referring to EN 301 549 sections
- In the WCAG 2.x Report section:
  - Correct title of Clauses 11 and 12
  - Match information structure of conformance clauses
- Amend WCAG version in conformance reqs

### 2.5 changes
- Consistent definition of "Not Evaluated"


ITIC change log: [VPATChangeTracking_February2025.docx](https://github.com/user-attachments/files/20776819/VPATChangeTracking_February2025.docx)