### PR TITLE
Nature VPAT language corrections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.DS_Store


### PR DESCRIPTION
This PR applies editorial amends in the Nature VPAT, including:

- References to Nature.com in main body now state "this product"
- Broken links (internal and external)