### PR TITLE
Reinstate SpringerLink file path

### DIFF
--- a/springerlink.md
+++ b/springerlink.md
@@ -1,0 +1,3 @@
+# SpringerLink is now Springer Nature Link
+SpringerLink has been rebranded to Springer Nature Link.
+All Accessibility Conformance Report (ACR) information, both current and historical, is available in full at the updated file path, [springer-nature-link.md](./springer-nature-link.md).


### PR DESCRIPTION
PR to reinstate the old springerlink.md file path and include a link to the current file path, springer-nature-link.md.